### PR TITLE
fix: add jquery in ProvidePlugin

### DIFF
--- a/packages/manager-layout-ovh/package.json
+++ b/packages/manager-layout-ovh/package.json
@@ -50,6 +50,7 @@
     "babel-eslint": "^8.2.6",
     "eslint": "^5.8.0",
     "eslint-config-airbnb-base": "^13.1.0",
+    "webpack": "^4.5.0",
     "webpack-merge": "^4.1.4"
   },
   "scripts": {

--- a/packages/manager-layout-ovh/src/index.js
+++ b/packages/manager-layout-ovh/src/index.js
@@ -5,7 +5,6 @@ import 'angular-resource';
 import translate from 'angular-translate';
 import _ from 'lodash';
 
-import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!lodash'; // eslint-disable-line
 
 import ssoAuth from 'ovh-angular-sso-auth';

--- a/packages/manager-layout-ovh/webpack.config.js
+++ b/packages/manager-layout-ovh/webpack.config.js
@@ -1,6 +1,7 @@
 const merge = require('webpack-merge');
 const path = require('path');
 const webpackConfig = require('@ovh-ux/manager-webpack-config');
+const webpack = require('webpack');
 
 module.exports = (env = {}) => {
   const { config } = webpackConfig({
@@ -22,5 +23,13 @@ module.exports = (env = {}) => {
         path.resolve(__dirname, '../../node_modules'),
       ],
     },
+    plugins: [
+      new webpack.ProvidePlugin({
+        $: 'jquery',
+        jquery: 'jquery',
+        jQuery: 'jquery',
+        'window.jQuery': 'jquery',
+      }),
+    ],
   });
 };


### PR DESCRIPTION
## add `jquery` in `ProvidePlugin`

### Description of the Change

`angular.js` looks for `window.jQuery` (cf: https://github.com/angular/angular.js/blob/master/src/Angular.js#L1890 )

Before `angular.element` used `jqLite`, with this fix it's now `jQuery`.

_This solution is recommended in the [webpack documentation](https://webpack.js.org/plugins/provide-plugin/#usage-jquery-with-angular-1)_

7a0e47e - fix: add jquery in ProvidePlugin

/cc @jleveugle @frenautvh @antleblanc

