### PR TITLE
fix(layout-ovh): change otb loadOnState to overthebox state

### DIFF
--- a/packages/manager-layout-ovh/src/sidebar/sidebar.constants.js
+++ b/packages/manager-layout-ovh/src/sidebar/sidebar.constants.js
@@ -166,7 +166,7 @@ export const SIDEBAR_CONFIG = {
     error: 'sidebar_load_error',
     category: 'overTheBox',
     icon: 'ovh-font ovh-font-overTheBox',
-    loadOnState: 'telecom.overTheBox',
+    loadOnState: 'overTheBox',
   },
   // temp for detecting missing sidebar config
   default: {


### PR DESCRIPTION
## change `OVER_THE_BOX.loadOnState` to `overTheBox` state

### Description of the Change

34b9ae8 - fix(layout-ovh): change otb loadOnState to overthebox state

/cc @jleveugle @frenautvh @antleblanc

