### PR TITLE
Clean constants

### DIFF
--- a/packages/manager-core/src/index.js
+++ b/packages/manager-core/src/index.js
@@ -25,13 +25,13 @@ angular
     translateAsyncLoader,
   ])
   .constant('constants', {})
-  .constant('LANGUAGES', LANGUAGES)
+  .constant('CORE_LANGUAGES', LANGUAGES)
 
-  .constant('REDIRECT_URLS', REDIRECT_URLS)
+  .constant('CORE_REDIRECT_URLS', REDIRECT_URLS)
   // TODO : remove TARGET constant
   // We have to deliver a SPA without any reference to the TARGET, should be managed by the API
   .constant('TARGET', 'EU')
-  .constant('URLS', URLS)
+  .constant('CORE_URLS', URLS)
   .provider('TranslateService', translateServiceProvider)
   .config(($translateProvider, translatePluggableLoaderProvider, TranslateServiceProvider) => {
     TranslateServiceProvider.setUserLocale();

--- a/packages/manager-core/src/index.js
+++ b/packages/manager-core/src/index.js
@@ -11,7 +11,7 @@ import translateServiceProvider from './translate/translate.service';
 import sessionService from './session/session.service';
 
 import {
-  MANAGER_URLS, LANGUAGES, REDIRECT_URLS, URLS,
+  LANGUAGES, REDIRECT_URLS, URLS,
 } from './manager-core.constants';
 
 const moduleName = 'ovhManagerCore';
@@ -26,7 +26,7 @@ angular
   ])
   .constant('constants', {})
   .constant('LANGUAGES', LANGUAGES)
-  .constant('MANAGER_URLS', MANAGER_URLS)
+
   .constant('REDIRECT_URLS', REDIRECT_URLS)
   // TODO : remove TARGET constant
   // We have to deliver a SPA without any reference to the TARGET, should be managed by the API

--- a/packages/manager-core/src/manager-core.constants.js
+++ b/packages/manager-core/src/manager-core.constants.js
@@ -490,7 +490,12 @@ export const URLS = {
       FI: 'https://docs.ovh.com/fi/storage/sync-rclone-object-storage/',
       IE: 'https://docs.ovh.com/ie/en/storage/sync-rclone-object-storage/',
     },
+    overTheBox: 'https://docs.ovh.com/display/public/CRXDSL/Accueil+xDSL',
   },
+  overTheBoxManager: 'http://overthebox.ovh',
+  orderExpressLite: 'https://www.ovhtelecom.fr/adsl/express-lite/',
+  orderBoost: 'https://www.ovhtelecom.fr/adsl/offres-de-connexion.xml',
+  keyGenHelp: 'https://www.ovh.com/fr/g1769.creation_des_cles_ssh',
 };
 
 export default {

--- a/packages/manager-core/src/manager-core.constants.js
+++ b/packages/manager-core/src/manager-core.constants.js
@@ -1,14 +1,3 @@
-export const MANAGER_URLS = {
-  default: 'https://www.ovh.com/manager/#/',
-  sunrise: 'https://www.ovh.com/manager/sunrise/index.html#/',
-  gamma: 'https://www.ovh.com/manager/sunrise/index.html#/',
-  v3: 'https://www.ovh.com/managerv3/home.pl',
-  portal: 'https://www.ovh.com/manager/portal/index.html#/',
-  partners: 'https://www.ovh.com/manager/partners/',
-  labs: 'https://www.ovh.com/manager/sunrise/uxlabs/#!/',
-};
-
-
 export const LANGUAGES = {
   available: [{
     name: 'Deutsch',
@@ -505,5 +494,5 @@ export const URLS = {
 };
 
 export default {
-  MANAGER_URLS, LANGUAGES, REDIRECT_URLS, URLS,
+  LANGUAGES, REDIRECT_URLS, URLS,
 };

--- a/packages/manager-core/src/translate/translate.service.js
+++ b/packages/manager-core/src/translate/translate.service.js
@@ -9,10 +9,10 @@ import map from 'lodash/map';
  * @description Manage translations
  */
 export default class TranslateServiceProvider {
-  constructor(LANGUAGES, TARGET) {
+  constructor(CORE_LANGUAGES, TARGET) {
     'ngInject';
 
-    this.LANGUAGES = LANGUAGES;
+    this.LANGUAGES = CORE_LANGUAGES;
     this.TARGET = TARGET;
     this.storageKey = 'univers-selected-language';
     this.localeRegex = /^([a-zA-Z]+)(?:[_-]([a-zA-Z]+))?$/;

--- a/packages/manager-layout-ovh/src/navbar/index.js
+++ b/packages/manager-layout-ovh/src/navbar/index.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 import core from '@ovh-ux/manager-core';
 
+import { MANAGER_URLS } from './navbar.constants';
 import template from './navbar.html';
 import controller from './navbar.controller';
 import navbarService from './navbar.service';
@@ -23,6 +24,7 @@ export default angular
     'oui',
     'ovh-angular-otrs',
   ])
+  .constant('MANAGER_URLS', MANAGER_URLS)
   .component('ovhManagerNavbar', {
     template,
     controller,

--- a/packages/manager-layout-ovh/src/navbar/navbar.constants.js
+++ b/packages/manager-layout-ovh/src/navbar/navbar.constants.js
@@ -1,0 +1,14 @@
+export const MANAGER_URLS = {
+  default: 'https://www.ovh.com/manager/#/',
+  sunrise: 'https://www.ovh.com/manager/sunrise/index.html#/',
+  gamma: 'https://www.ovh.com/manager/sunrise/index.html#/',
+  v3: 'https://www.ovh.com/managerv3/home.pl',
+  portal: 'https://www.ovh.com/manager/portal/index.html#/',
+  partners: 'https://www.ovh.com/manager/partners/',
+  labs: 'https://www.ovh.com/manager/sunrise/uxlabs/#!/',
+};
+
+
+export default {
+  MANAGER_URLS,
+};

--- a/packages/manager-layout-ovh/src/navbar/navbar.service.js
+++ b/packages/manager-layout-ovh/src/navbar/navbar.service.js
@@ -8,16 +8,16 @@ export default class ManagerNavbarService {
     $translate,
     asyncLoader,
     // FeatureAvailabilityService,
-    LANGUAGES,
+    CORE_LANGUAGES,
     MANAGER_URLS,
     NavbarNotificationService,
     OtrsPopupService,
-    REDIRECT_URLS,
+    CORE_REDIRECT_URLS,
     SessionService,
     ssoAuthentication,
     TARGET,
     TranslateService,
-    URLS,
+    CORE_URLS,
   ) {
     'ngInject';
 
@@ -25,17 +25,17 @@ export default class ManagerNavbarService {
     this.$translate = $translate;
     // this.featureAvailabilityService = FeatureAvailabilityService;
     this.asyncLoader = asyncLoader;
-    this.LANGUAGES = LANGUAGES;
+    this.LANGUAGES = CORE_LANGUAGES;
     this.MANAGER_URLS = MANAGER_URLS;
     this.navbarNotificationService = NavbarNotificationService;
     this.otrsPopupService = OtrsPopupService;
-    this.REDIRECT_URLS = REDIRECT_URLS;
+    this.REDIRECT_URLS = CORE_REDIRECT_URLS;
 
     this.sessionService = SessionService;
     this.ssoAuthentication = ssoAuthentication;
     this.TARGET = TARGET;
     this.translateService = TranslateService;
-    this.URLS = URLS;
+    this.URLS = CORE_URLS;
   }
 
   getAssistanceMenu(locale) {

--- a/packages/manager-overthebox/src/overTheBox.controller.js
+++ b/packages/manager-overthebox/src/overTheBox.controller.js
@@ -1,10 +1,10 @@
 export default /* @ngInject */ function
-($stateParams, $translate, $q, OvhApiOverTheBox, SidebarMenu, TucToast, URLS) {
+($stateParams, $translate, $q, OvhApiOverTheBox, SidebarMenu, TucToast, CORE_URLS) {
   const self = this;
 
   self.dice = Math.round(Math.random() * 100);
-  self.expressLiteOrder = URLS.orderExpressLite;
-  self.orderBoost = URLS.orderBoost;
+  self.expressLiteOrder = CORE_URLS.orderExpressLite;
+  self.orderBoost = CORE_URLS.orderBoost;
 
   this.disabledRemote = true;
 

--- a/packages/manager-overthebox/src/remote/overTheBox-remote.controller.js
+++ b/packages/manager-overthebox/src/remote/overTheBox-remote.controller.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import _ from 'lodash';
 
 export default /* @ngInject */ function
-($stateParams, $translate, $scope, $q, URLS, OVER_THE_BOX, OVERTHEBOX_REMOTE_STATUS,
+($stateParams, $translate, $scope, $q, CORE_URLS, OVER_THE_BOX, OVERTHEBOX_REMOTE_STATUS,
   OvhApiOverTheBox, TucToastError, TucToast, TucIpAddress, tucValidator) {
   const self = this;
 
@@ -14,7 +14,7 @@ export default /* @ngInject */ function
   this.remoteStatus = OVERTHEBOX_REMOTE_STATUS;
 
   this.validator = tucValidator;
-  this.publicKeyHelperUrl = URLS.keyGenHelp;
+  this.publicKeyHelperUrl = CORE_URLS.keyGenHelp;
   this.pickerOpened = false;
   this.maxRemotes = OVER_THE_BOX.maxRemotes;
 

--- a/packages/manager-overthebox/src/warning/overTheBox-warning.controller.js
+++ b/packages/manager-overthebox/src/warning/overTheBox-warning.controller.js
@@ -3,11 +3,11 @@ import angular from 'angular';
 const moduleName = 'ovhManagerOtbWarning';
 
 angular.module(moduleName, [])
-  .controller('OrderOverTheBoxWarningCtrl', function orderOverTheBoxWarningCtrl(URLS, REDIRECT_URLS) {
-    this.overTheBoxManager = URLS.overTheBoxManager;
-    this.guide = URLS.guides.overTheBox;
-    this.home = URLS.guides.home;
-    this.paymentMeans = REDIRECT_URLS.paymentMeans;
+  .controller('OrderOverTheBoxWarningCtrl', function orderOverTheBoxWarningCtrl(CORE_URLS, CORE_REDIRECT_URLS) {
+    this.overTheBoxManager = CORE_URLS.overTheBoxManager;
+    this.guide = CORE_URLS.guides.overTheBox;
+    this.home = CORE_URLS.guides.home;
+    this.paymentMeans = CORE_REDIRECT_URLS.paymentMeans;
   });
 
 export default moduleName;


### PR DESCRIPTION
## Clean constants

### Description of the Change

- Move `MANAGER_URLS` from `manager-core` to `manager-layout-ovh`
- Prefix core constants with `CORE_`
- Add missing constants

8aac931 - fix(core): add missing constants
97f83ab - refactor(core): update core constant name
e8ebcc6 - fix: move MANAGER_URLS constants from core to navbar

/cc @jleveugle @frenautvh @antleblanc

