### PR TITLE
fix(manager-layout-ovh): remove default  prefix

### DIFF
--- a/packages/manager/layout-ovh/src/index.js
+++ b/packages/manager/layout-ovh/src/index.js
@@ -91,6 +91,9 @@ angular
       return localConfig;
     },
   }))
+  .config(($locationProvider) => {
+    $locationProvider.hashPrefix('');
+  })
   .config((ssoAuthenticationProvider, $httpProvider, OVH_SSO_AUTH_LOGIN_URL) => {
     ssoAuthenticationProvider.setLoginUrl(OVH_SSO_AUTH_LOGIN_URL);
     ssoAuthenticationProvider.setLogoutUrl(`${OVH_SSO_AUTH_LOGIN_URL}?action=disconnect`);


### PR DESCRIPTION
ref: https://docs.angularjs.org/api/ng/provider/$locationProvider#hashPrefix