### PR TITLE
Add  `*.md` files to the lint-staged configuration

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -9,5 +9,8 @@
   "*.less": [
     "stylelint 'packages/**/*.less' --fix",
     "git add"
+  ],
+  "*.md": [
+    "remark -qf ."
   ]
 }


### PR DESCRIPTION
## Description of the Change

94fc3b6 — test(lint): add markdown files to the lint-staged configuration