### PR TITLE
test(freefax): add standalone tests

### DIFF
--- a/packages/manager/apps/freefax/cypress.json
+++ b/packages/manager/apps/freefax/cypress.json
@@ -1,0 +1,5 @@
+{
+  "baseUrl": "http://localhost:9000",
+  "chromeWebSecurity": false,
+  "video": false
+}

--- a/packages/manager/apps/freefax/cypress/.eslintrc.json
+++ b/packages/manager/apps/freefax/cypress/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "cypress"
+  ],
+  "env": {
+    "cypress/globals": true
+  }
+}

--- a/packages/manager/apps/freefax/cypress/fixtures/2api_freefax_details.json
+++ b/packages/manager/apps/freefax/cypress/fixtures/2api_freefax_details.json
@@ -1,0 +1,37 @@
+{
+  "number": "0033123456789",
+  "fromName": "Service télécopie",
+  "redirectionEmail": [
+    "john@doe.com"
+  ],
+  "faxTagLine": "De %%l|%c|Page %%P sur %%T",
+  "faxQuality": "high",
+  "fromEmail": "no-reply@doe.com",
+  "faxMaxCall": 5,
+  "domain": null,
+  "faxs": 111794,
+  "points": 223589,
+  "status": "ok",
+  "voicemail": {
+    "forcePassword": false,
+    "greetingType": "default",
+    "isNewVersion": true,
+    "fromEmail": "no-reply@doe.com",
+    "shortGreetingSoundId": null,
+    "temporaryGreetingActivated": false,
+    "redirectionEmails": [
+      {
+        "type": "simple",
+        "email": "john@doe.com"
+      }
+    ],
+    "fullGreetingSoundId": null,
+    "temporaryGreetingSoundId": null,
+    "unreadMessages": 0,
+    "audioFormat": "mp3",
+    "annouceMessage": "",
+    "keepMessage": false,
+    "doNotRecord": false,
+    "fromName": "Service messagerie"
+  }
+}

--- a/packages/manager/apps/freefax/cypress/fixtures/2api_freefax_notifications.json
+++ b/packages/manager/apps/freefax/cypress/fixtures/2api_freefax_notifications.json
@@ -1,0 +1,8 @@
+[
+  {
+    "email": "john@doe.com",
+    "type": "simple",
+    "fax": true,
+    "source": "both"
+  }
+]

--- a/packages/manager/apps/freefax/cypress/fixtures/apiv6_freefax.json
+++ b/packages/manager/apps/freefax/cypress/fixtures/apiv6_freefax.json
@@ -1,0 +1,852 @@
+{
+  "models": {
+    "telephony.ServiceVoicemailNotifications": {
+      "namespace": "telephony",
+      "id": "ServiceVoicemailNotifications",
+      "description": "Voicemail configuration",
+      "properties": {
+        "email": {
+          "canBeNull": 0,
+          "type": "string",
+          "description": null
+        },
+        "type": {
+          "canBeNull": 0,
+          "type": "telephony.ServiceVoicemailMailOptionEnum",
+          "description": null
+        }
+      }
+    },
+    "service.RenewalTypeEnum": {
+      "namespace": "service",
+      "enum": [
+        "automaticForcedProduct",
+        "automaticV2012",
+        "automaticV2014",
+        "automaticV2016",
+        "manual",
+        "oneShot",
+        "option"
+      ],
+      "id": "RenewalTypeEnum",
+      "enumType": "string",
+      "description": "Detailed renewal type of a service"
+    },
+    "telephony.FaxSendingTries": {
+      "namespace": "telephony",
+      "enum": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9"
+      ],
+      "id": "FaxSendingTries",
+      "enumType": "long",
+      "description": "Number of tries when sending a fax"
+    },
+    "telephony.VoicemailGreetingEnum": {
+      "namespace": "telephony",
+      "enum": [
+        "default",
+        "full",
+        "short"
+      ],
+      "id": "VoicemailGreetingEnum",
+      "enumType": "string",
+      "description": "Greeting type"
+    },
+    "telephony.ServiceVoicemailMailOptionEnum": {
+      "namespace": "telephony",
+      "enum": [
+        "attachment",
+        "simple"
+      ],
+      "id": "ServiceVoicemailMailOptionEnum",
+      "enumType": "string",
+      "description": "Voicemail configuration"
+    },
+    "telephony.VoicemailProperties": {
+      "namespace": "telephony",
+      "id": "VoicemailProperties",
+      "description": "Voicemail Properties",
+      "properties": {
+        "fromName": {
+          "fullType": "string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": "Name from which emails will be sent",
+          "readOnly": 0
+        },
+        "fullGreetingSoundId": {
+          "fullType": "long",
+          "canBeNull": 1,
+          "type": "long",
+          "description": "Sound ID of the long greeeting",
+          "readOnly": 0
+        },
+        "doNotRecord": {
+          "fullType": "boolean",
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "Don't allow callers to leave voicemails",
+          "readOnly": 0
+        },
+        "temporaryGreetingSoundId": {
+          "fullType": "long",
+          "canBeNull": 1,
+          "type": "long",
+          "description": "Sound ID of the temporary greeeting",
+          "readOnly": 0
+        },
+        "fromEmail": {
+          "fullType": "string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": "Email address from which emails will be sent",
+          "readOnly": 0
+        },
+        "unreadMessages": {
+          "fullType": "long",
+          "canBeNull": 0,
+          "type": "long",
+          "description": "Quantity of unread voicemails",
+          "readOnly": 1
+        },
+        "keepMessage": {
+          "fullType": "boolean",
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "Don't delete voicemails after they've been sent by email",
+          "readOnly": 0
+        },
+        "temporaryGreetingActivated": {
+          "fullType": "boolean",
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "Play the temporary greeting instead of the regular one",
+          "readOnly": 0
+        },
+        "audioFormat": {
+          "fullType": "telephony.ServiceVoicemailAudioFormatEnum",
+          "canBeNull": 0,
+          "type": "telephony.ServiceVoicemailAudioFormatEnum",
+          "description": "Format of the voicemail audio file attached to emails",
+          "readOnly": 0
+        },
+        "redirectionEmails": {
+          "fullType": "telephony.ServiceVoicemailNotifications[]",
+          "canBeNull": 0,
+          "type": "telephony.ServiceVoicemailNotifications[]",
+          "description": "Email addresses to notify when a new voicemail is left",
+          "readOnly": 0
+        },
+        "forcePassword": {
+          "fullType": "boolean",
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "Force password request to access the voicemail panel",
+          "readOnly": 0
+        },
+        "shortGreetingSoundId": {
+          "fullType": "long",
+          "canBeNull": 1,
+          "type": "long",
+          "description": "Sound ID of the short greeting played before an automated message",
+          "readOnly": 0
+        },
+        "annouceMessage": {
+          "fullType": "string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": "Name of the voicemail panel announce file",
+          "readOnly": 1
+        },
+        "greetingType": {
+          "fullType": "telephony.VoicemailGreetingEnum",
+          "canBeNull": 0,
+          "type": "telephony.VoicemailGreetingEnum",
+          "description": "Type of the greeting to play",
+          "readOnly": 0
+        },
+        "isNewVersion": {
+          "fullType": "boolean",
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "Current voicemail version",
+          "readOnly": 1
+        }
+      }
+    },
+    "freefax.FreefaxProperties": {
+      "namespace": "freefax",
+      "id": "FreefaxProperties",
+      "description": "Freefax properties",
+      "properties": {
+        "fromName": {
+          "fullType": "string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": "Name of the sender of the email",
+          "readOnly": 0
+        },
+        "redirectionEmail": {
+          "fullType": "string[]",
+          "canBeNull": 0,
+          "type": "string[]",
+          "description": "Email address to redirect fax response.",
+          "readOnly": 0
+        },
+        "number": {
+          "fullType": "phoneNumber",
+          "canBeNull": 0,
+          "type": "phoneNumber",
+          "description": "Freefax number in international format",
+          "readOnly": 1
+        },
+        "faxQuality": {
+          "fullType": "telephony.FaxQualityEnum",
+          "canBeNull": 0,
+          "type": "telephony.FaxQualityEnum",
+          "description": "Quality of fax sending",
+          "readOnly": 0
+        },
+        "faxMaxCall": {
+          "fullType": "telephony.FaxSendingTries",
+          "canBeNull": 0,
+          "type": "telephony.FaxSendingTries",
+          "description": "Number of max tentative of fax sending",
+          "readOnly": 0
+        },
+        "faxTagLine": {
+          "fullType": "string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": "Customised freefax header",
+          "readOnly": 0
+        },
+        "fromEmail": {
+          "fullType": "string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": "FROM email header",
+          "readOnly": 0
+        }
+      }
+    },
+    "service.RenewType": {
+      "namespace": "service",
+      "id": "RenewType",
+      "description": "Map a possible renew for a specific service",
+      "properties": {
+        "manualPayment": {
+          "canBeNull": 1,
+          "type": "boolean",
+          "description": "The service needs to be manually renewed and paid"
+        },
+        "period": {
+          "canBeNull": 1,
+          "type": "long",
+          "description": "period of renew in month"
+        },
+        "forced": {
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "The service forced to be renewed"
+        },
+        "automatic": {
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "The service is automatically renewed"
+        },
+        "deleteAtExpiration": {
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "The service will be deleted at expiration"
+        }
+      }
+    },
+    "telephony.VoicefaxRoutingEnum": {
+      "namespace": "telephony",
+      "enum": [
+        "fax",
+        "voicemail"
+      ],
+      "id": "VoicefaxRoutingEnum",
+      "enumType": "string",
+      "description": "All existing type of routing for a voicemail"
+    },
+    "services.Service": {
+      "namespace": "services",
+      "id": "Service",
+      "description": "Details about a Service",
+      "properties": {
+        "renewalType": {
+          "fullType": "service.RenewalTypeEnum",
+          "canBeNull": 0,
+          "type": "service.RenewalTypeEnum",
+          "description": null,
+          "readOnly": 1
+        },
+        "status": {
+          "fullType": "service.StateEnum",
+          "canBeNull": 0,
+          "type": "service.StateEnum",
+          "description": null,
+          "readOnly": 1
+        },
+        "engagedUpTo": {
+          "fullType": "date",
+          "canBeNull": 1,
+          "type": "date",
+          "description": null,
+          "readOnly": 1
+        },
+        "possibleRenewPeriod": {
+          "fullType": "long[]",
+          "canBeNull": 1,
+          "type": "long[]",
+          "description": "All the possible renew period of your service in month",
+          "readOnly": 1
+        },
+        "serviceId": {
+          "fullType": "coreTypes.ServiceId:long",
+          "canBeNull": 0,
+          "type": "long",
+          "description": null,
+          "readOnly": 1
+        },
+        "contactBilling": {
+          "fullType": "coreTypes.AccountId:string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": null,
+          "readOnly": 1
+        },
+        "renew": {
+          "fullType": "service.RenewType",
+          "canBeNull": 1,
+          "type": "service.RenewType",
+          "description": "Way of handling the renew",
+          "readOnly": 0
+        },
+        "domain": {
+          "fullType": "string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": null,
+          "readOnly": 1
+        },
+        "contactTech": {
+          "fullType": "coreTypes.AccountId:string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": null,
+          "readOnly": 1
+        },
+        "expiration": {
+          "fullType": "date",
+          "canBeNull": 0,
+          "type": "date",
+          "description": null,
+          "readOnly": 1
+        },
+        "contactAdmin": {
+          "fullType": "coreTypes.AccountId:string",
+          "canBeNull": 0,
+          "type": "string",
+          "description": null,
+          "readOnly": 1
+        },
+        "creation": {
+          "fullType": "date",
+          "canBeNull": 0,
+          "type": "date",
+          "description": null,
+          "readOnly": 1
+        },
+        "canDeleteAtExpiration": {
+          "fullType": "boolean",
+          "canBeNull": 0,
+          "type": "boolean",
+          "description": "Indicates that the service can be set up to be deleted at expiration",
+          "readOnly": 1
+        }
+      }
+    },
+    "telephony.VoicemailNumbers": {
+      "namespace": "telephony",
+      "id": "VoicemailNumbers",
+      "description": "Internal and external numbers for voicemail service",
+      "properties": {
+        "external": {
+          "canBeNull": 0,
+          "type": "string",
+          "description": "The external voicemail number"
+        },
+        "internal": {
+          "canBeNull": 0,
+          "type": "string",
+          "description": "The internal voicemail number"
+        }
+      }
+    },
+    "telephony.ServiceVoicemailAudioFormatEnum": {
+      "namespace": "telephony",
+      "enum": [
+        "aiff",
+        "au",
+        "flac",
+        "mp3",
+        "ogg",
+        "wav"
+      ],
+      "id": "ServiceVoicemailAudioFormatEnum",
+      "enumType": "string",
+      "description": "Voicemail audio format"
+    },
+    "service.StateEnum": {
+      "namespace": "service",
+      "enum": [
+        "expired",
+        "inCreation",
+        "ok",
+        "pendingDebt",
+        "unPaid"
+      ],
+      "id": "StateEnum",
+      "enumType": "string",
+      "description": ""
+    },
+    "freefax.BalanceInformations": {
+      "namespace": "freefax",
+      "id": "BalanceInformations",
+      "description": "Return credit balance informations structure",
+      "properties": {
+        "faxs": {
+          "canBeNull": 0,
+          "type": "long",
+          "description": "The number of equivalement remaining french faxs"
+        },
+        "points": {
+          "canBeNull": 0,
+          "type": "long",
+          "description": "Total balance available in points"
+        }
+      }
+    },
+    "telephony.FaxQualityEnum": {
+      "namespace": "telephony",
+      "enum": [
+        "best",
+        "high",
+        "normal"
+      ],
+      "id": "FaxQualityEnum",
+      "enumType": "string",
+      "description": "Available quality for fax documents"
+    }
+  },
+  "apiVersion": "1.0",
+  "resourcePath": "/freefax",
+  "apis": [
+    {
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "description": "Get this object properties",
+          "responseType": "services.Service",
+          "parameters": [
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "services.Service",
+          "resellerOnly": false
+        },
+        {
+          "httpMethod": "PUT",
+          "description": "Alter this object properties",
+          "responseType": "void",
+          "parameters": [
+            {
+              "fullType": "services.Service",
+              "required": 1,
+              "dataType": "services.Service",
+              "paramType": "body",
+              "description": "New object properties"
+            },
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "void",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}/serviceInfos",
+      "description": "Details about a Service"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "description": "Get this object properties",
+          "responseType": "freefax.FreefaxProperties",
+          "parameters": [
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "freefax.FreefaxProperties",
+          "resellerOnly": false
+        },
+        {
+          "httpMethod": "PUT",
+          "description": "Alter this object properties",
+          "responseType": "void",
+          "parameters": [
+            {
+              "fullType": "freefax.FreefaxProperties",
+              "required": 1,
+              "dataType": "freefax.FreefaxProperties",
+              "paramType": "body",
+              "description": "New object properties"
+            },
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "void",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}",
+      "description": "Freefax properties"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "description": "Get this object properties",
+          "responseType": "telephony.VoicemailProperties",
+          "parameters": [
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "telephony.VoicemailProperties",
+          "resellerOnly": false
+        },
+        {
+          "httpMethod": "PUT",
+          "description": "Alter this object properties",
+          "responseType": "void",
+          "parameters": [
+            {
+              "fullType": "telephony.VoicemailProperties",
+              "required": 1,
+              "dataType": "telephony.VoicemailProperties",
+              "paramType": "body",
+              "description": "New object properties"
+            },
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "void",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}/voicemail",
+      "description": "Voicemail Properties"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "POST",
+          "description": "Disable/Enable voicemail. Available only if the line has fax capabilities",
+          "responseType": "void",
+          "parameters": [
+            {
+              "fullType": "telephony.VoicefaxRoutingEnum",
+              "required": 1,
+              "dataType": "telephony.VoicefaxRoutingEnum",
+              "paramType": "body",
+              "name": "routing",
+              "description": "Activate or Desactivate voicemail on the line"
+            },
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "void",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}/voicemail/changeRouting",
+      "description": "changeRouting operations"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "description": "Get number for internal and external voicemail",
+          "responseType": "telephony.VoicemailNumbers",
+          "parameters": [
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "telephony.VoicemailNumbers",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}/voicemail/voicemailNumbers",
+      "description": "voicemailNumbers operations"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "POST",
+          "description": "Change the voicemail password. It must be 4 digit",
+          "responseType": "void",
+          "parameters": [
+            {
+              "fullType": "password",
+              "required": 1,
+              "dataType": "password",
+              "paramType": "body",
+              "name": "password",
+              "description": "The password"
+            },
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "void",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}/voicemail/changePassword",
+      "description": "changePassword operations"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "description": "Get the status of the voicemail. Available only if the line has fax capabilities",
+          "responseType": "telephony.VoicefaxRoutingEnum",
+          "parameters": [
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "telephony.VoicefaxRoutingEnum",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}/voicemail/routing",
+      "description": "routing operations"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "POST",
+          "description": "Generates a new password for your fax account",
+          "responseType": "password",
+          "parameters": [
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "password",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}/changePassword",
+      "description": "changePassword operations"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "description": "Main service attached to freefax",
+          "responseType": "string",
+          "parameters": [
+            {
+              "fullType": "string",
+              "required": 1,
+              "dataType": "string",
+              "paramType": "path",
+              "name": "serviceName",
+              "description": "Freefax number"
+            }
+          ],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "string",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/{serviceName}/mainService",
+      "description": "mainService operations"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "description": "List available services",
+          "responseType": "string[]",
+          "parameters": [],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "string[]",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax",
+      "description": "Operations about the VOIP service"
+    },
+    {
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "description": "Get the credit balance and the remaining pages available for all our freefax",
+          "responseType": "freefax.BalanceInformations",
+          "parameters": [],
+          "apiStatus": {
+            "value": "PRODUCTION",
+            "description": "Stable production version"
+          },
+          "noAuthentication": 0,
+          "responseFullType": "freefax.BalanceInformations",
+          "resellerOnly": false
+        }
+      ],
+      "path": "/freefax/credits",
+      "description": "Get the credit balance and the remaining pages available for all our freefax"
+    }
+  ],
+  "basePath": "http://api.v6.ha.ovh.net/1.0"
+}

--- a/packages/manager/apps/freefax/cypress/fixtures/apiv6_freefax_voicemail.json
+++ b/packages/manager/apps/freefax/cypress/fixtures/apiv6_freefax_voicemail.json
@@ -1,0 +1,22 @@
+{
+  "shortGreetingSoundId": null,
+  "greetingType": "default",
+  "temporaryGreetingSoundId": null,
+  "forcePassword": false,
+  "doNotRecord": false,
+  "fullGreetingSoundId": null,
+  "keepMessage": false,
+  "audioFormat": "mp3",
+  "redirectionEmails": [
+    {
+      "type": "simple",
+      "email": "john@doe.com"
+    }
+  ],
+  "annouceMessage": "",
+  "unreadMessages": 0,
+  "fromEmail": "no-reply@doe.com",
+  "fromName": "Service messagerie",
+  "temporaryGreetingActivated": false,
+  "isNewVersion": true
+}

--- a/packages/manager/apps/freefax/cypress/fixtures/me.json
+++ b/packages/manager/apps/freefax/cypress/fixtures/me.json
@@ -1,0 +1,33 @@
+{
+    "firstname": "John",
+    "vat": "",
+    "ovhSubsidiary": "FR",
+    "area": "",
+    "birthDay": "1900-01-02",
+    "nationalIdentificationNumber": null,
+    "spareEmail": "john@doe.com",
+    "ovhCompany": "OVH",
+    "state": "complete",
+    "phoneCountry": "FR",
+    "email": "john@doe.com",
+    "currency": {
+        "symbol": "€",
+        "code": "EUR"
+    },
+    "city": "Roubaix",
+    "fax": "",
+    "nichandle": "jd000000-ovh",
+    "address": "2 rue Kellermann",
+    "companyNationalIdentificationNumber": null,
+    "birthCity": "Roubaix",
+    "country": "FR",
+    "language": "fr_FR",
+    "organisation": "OVH",
+    "name": "Doe",
+    "phone": "+33.123456789",
+    "sex": "male",
+    "zip": "59100",
+    "corporationType": "",
+    "customerCode": "0000-0000-00",
+    "legalform": "association"
+}

--- a/packages/manager/apps/freefax/cypress/integration/standalone.spec.js
+++ b/packages/manager/apps/freefax/cypress/integration/standalone.spec.js
@@ -1,0 +1,144 @@
+import Page from '../support/po';
+
+const { DashboardPage, NotificationsPage, VoicemailConfigurationPage } = Page.FreefaxPage;
+
+describe('FreeFax should be a standalone', () => {
+  const serviceId = '0033123456789';
+
+  beforeEach(() => {
+    cy.fixture('2api_freefax_details').as('fixture_2api_freefax_details');
+
+    cy.server();
+    cy.route(
+      'GET',
+      '/engine/apiv6/me',
+      'fixtures:me',
+    ).as('apiMe');
+
+    cy.get('@fixture_2api_freefax_details')
+      .then((json) => {
+        cy.route({
+          method: 'GET',
+          url: `/engine/2api/freefax/${serviceId}/details`,
+          status: 200,
+          response: json,
+          headers: {
+            'content-type': 'application/json',
+          },
+        })
+          .as('2apiFreefaxDetails');
+      });
+
+    cy.route(
+      'GET',
+      '/engine/apiv6/freefax.json',
+      'fixtures:apiv6_freefax',
+    );
+
+    cy.route(
+      'GET',
+      `/engine/2api/freefax/notifications/${serviceId}`,
+      'fixtures:2api_freefax_notifications',
+    );
+
+    cy.route({
+      method: 'GET',
+      url: `/engine/apiv6/freefax/${serviceId}/voicemail/routing`,
+      status: 200,
+      response: '"fax"',
+    })
+      .as('apiv6FreefaxVoicemailRouting');
+
+    cy.route('GET', `/engine/apiv6/freefax/${serviceId}/voicemail`, 'fixture:apiv6_freefax_voicemail')
+      .as('apiv6FreefaxVoicemail');
+  });
+
+  it('should navigate between states', () => {
+    cy.window().its('console').then((csl) => {
+      cy.spy(csl, 'error');
+    });
+
+    const dashboard = new DashboardPage(serviceId);
+    dashboard.visit();
+    dashboard.isVisible();
+    cy.createTranslateSpy();
+
+    cy.wait([
+      '@apiMe',
+      '@2apiFreefaxDetails',
+      '@apiv6FreefaxVoicemailRouting',
+    ]);
+
+    cy.checkTranslations();
+
+    const notifications = dashboard.navigateToNotifications();
+    notifications.checkUrl();
+    notifications.isVisible();
+    cy.checkTranslations();
+    notifications.goBack();
+
+    dashboard.checkUrl();
+    dashboard.isVisible();
+
+    const voicemailConfiguration = dashboard.navigateToVoiceMailConfiguration();
+    voicemailConfiguration.checkUrl();
+    voicemailConfiguration.isVisible();
+    cy.wait('@apiv6FreefaxVoicemail');
+    cy.checkTranslations();
+
+    voicemailConfiguration.goBack();
+    dashboard.checkUrl();
+    dashboard.isVisible();
+
+    cy.checkTranslateInstant();
+  });
+
+  it('should have dashboard translations', () => {
+    const dashboard = new DashboardPage(serviceId);
+    dashboard.visit();
+    dashboard.isVisible();
+    cy.createTranslateSpy();
+
+    cy.wait([
+      '@apiMe',
+      '@2apiFreefaxDetails',
+      '@apiv6FreefaxVoicemailRouting',
+    ]);
+
+    cy.checkTranslations();
+    cy.checkTranslateInstant();
+  });
+
+  it('should have notifications translations', () => {
+    const notifications = new NotificationsPage(serviceId);
+    notifications.visit();
+    notifications.isVisible();
+    cy.createTranslateSpy();
+
+    cy.wait([
+      '@apiMe',
+      '@2apiFreefaxDetails',
+      '@apiv6FreefaxVoicemailRouting',
+    ]);
+
+    cy.checkTranslations();
+    cy.checkTranslateInstant();
+  });
+
+  it('should have voicemailConfiguration translations', () => {
+    const voicemailConfiguration = new VoicemailConfigurationPage(serviceId);
+    voicemailConfiguration.visit();
+    voicemailConfiguration.isVisible();
+    cy.createTranslateSpy();
+
+    cy.wait([
+      '@apiMe',
+      '@2apiFreefaxDetails',
+      '@apiv6FreefaxVoicemailRouting',
+      '@apiv6FreefaxVoicemail',
+    ]);
+
+    cy.checkTranslations();
+    cy.checkTranslateInstant();
+  });
+});

--- a/packages/manager/apps/freefax/cypress/plugins/index.js
+++ b/packages/manager/apps/freefax/cypress/plugins/index.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+module.exports = () => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+};

--- a/packages/manager/apps/freefax/cypress/support/commands.js
+++ b/packages/manager/apps/freefax/cypress/support/commands.js
@@ -1,0 +1,123 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This is will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+
+// Translations Commands
+// $translate.instant : call cy.createTranslateSpy() and call cy.checkTranslateInstant();
+// $translate directives : cy.checkTranslations();
+Cypress.Commands.add('createTranslateSpy', () => {
+  cy.getAngularInjector('$translate')
+    .then($translate => cy.spy($translate, 'instant').as('$translateInstantSpy'));
+});
+
+Cypress.Commands.add('checkTranslateInstant', () => {
+  const checkTranslateInstant = (translationsKeys) => {
+    cy.get('@$translateInstantSpy')
+      .then(($translateInstantSpy) => {
+        cy.log(`$translate.instant called ${$translateInstantSpy.callCount} times`);
+
+        for (let callIndex = 0; callIndex < $translateInstantSpy.callCount; callIndex += 1) {
+          const call = $translateInstantSpy.getCall(callIndex);
+          expect(translationsKeys).to.include(call.args[0]);
+        }
+      });
+  };
+
+  cy.getAngularInjector('$translate')
+    .then(($translate) => {
+      const translations = $translate.getTranslationTable();
+      const translationsKeys = Object.keys(translations);
+
+      checkTranslateInstant(translationsKeys);
+    });
+});
+
+Cypress.Commands.add('checkTranslations', () => {
+  const escapeRegex = string => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const expectMatchTranslation = (content, translation) => {
+    const translationRegex = new RegExp(escapeRegex(translation).replace(/\\{\\{(.*)\\}\\}/g, '.*'), 'g');
+    expect(content).to.match(translationRegex);
+  };
+
+  const checkTranslateDirective = (translations) => {
+    cy.get('[data-translate]').each((element) => {
+      const elementTranslation = element.data('translate');
+      expect(translations).to.have.property(elementTranslation);
+
+      const translation = translations[element.data('translate')];
+      expectMatchTranslation(element.html(), translation);
+    });
+  };
+
+  const checkTranslateAttrDirective = (translations) => {
+    cy.getAngular()
+      .then((angular) => {
+        cy.getAngularInjector('$parse')
+          .then(($parse) => {
+            const dataTranslateAttrsElements = Cypress.$('[data-translate-attr]');
+            if (dataTranslateAttrsElements.length) {
+              dataTranslateAttrsElements.each((index, element) => {
+                const $element = Cypress.$(element);
+                const translateAttr = $element.data('translateAttr');
+
+                const translateAttributes = $parse(translateAttr)();
+
+                angular.forEach(translateAttributes, (translationId, attribute) => {
+                  expect(translations).to.have.property(translationId);
+
+                  const translation = translations[translationId];
+                  expectMatchTranslation(element.getAttribute(attribute), translation);
+                });
+              });
+            }
+          });
+      });
+  };
+
+  cy.getAngularInjector('$translate')
+    .then(($translate) => {
+      const translations = $translate.getTranslationTable();
+
+      checkTranslateDirective(translations);
+      checkTranslateAttrDirective(translations);
+    });
+});
+
+
+// AngularJS commands
+// get AngularJS instance
+Cypress.Commands.add('getAngular', () => cy.window().its('angular'));
+
+// get AngularJS scope for element
+Cypress.Commands.add('getAngularScope', element => cy.getAngular().then(ng => ng.element(element).scope()));
+
+// get service from AngularJS injector
+Cypress.Commands.add('getAngularInjector', injected => cy.getAngular()
+  .then((angular) => {
+    cy.document()
+      .then(document => angular.element(document.body).injector().get(injected));
+  }));

--- a/packages/manager/apps/freefax/cypress/support/index.js
+++ b/packages/manager/apps/freefax/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/packages/manager/apps/freefax/cypress/support/po/base.js
+++ b/packages/manager/apps/freefax/cypress/support/po/base.js
@@ -1,0 +1,32 @@
+export default class BasePage {
+  constructor() {
+    this.mainSection = 'body';
+    this.hashUrl = '#!/';
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getE2E(name) {
+    return cy.get(`[data-e2e-id="${name}"]`);
+  }
+
+  getMainSection() {
+    return this.getE2E(this.mainSection);
+  }
+
+  isVisible() {
+    return this.getMainSection().should('be.visible');
+  }
+
+  getHashUrl() {
+    return this.hashUrl;
+  }
+
+  checkUrl() {
+    cy.hash().should('include', this.getHashUrl());
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  visit() {
+    return cy.visit(this.getHashUrl());
+  }
+}

--- a/packages/manager/apps/freefax/cypress/support/po/freefax/dashboard.js
+++ b/packages/manager/apps/freefax/cypress/support/po/freefax/dashboard.js
@@ -1,0 +1,27 @@
+import BasePage from '../base';
+import NotificationsPage from './notifications';
+import VoicemailConfigurationPage from './voicemailConfiguration';
+
+export default class DashboardPage extends BasePage {
+  constructor(serviceId) {
+    super();
+
+    this.serviceId = serviceId;
+
+    this.mainSection = 'freefax:section';
+    this.hashUrl = `#!/freefax/${this.serviceId}`;
+  }
+
+  navigateToNotifications() {
+    this.getE2E('freefax:navigation:notifications')
+      .click();
+
+    return new NotificationsPage(this.serviceId);
+  }
+
+  navigateToVoiceMailConfiguration() {
+    this.getE2E('freefax:navigation:voicemailConfiguration')
+      .click();
+    return new VoicemailConfigurationPage(this.serviceId);
+  }
+}

--- a/packages/manager/apps/freefax/cypress/support/po/freefax/index.js
+++ b/packages/manager/apps/freefax/cypress/support/po/freefax/index.js
@@ -1,0 +1,9 @@
+import DashboardPage from './dashboard';
+import NotificationsPage from './notifications';
+import VoicemailConfigurationPage from './voicemailConfiguration';
+
+export default {
+  DashboardPage,
+  NotificationsPage,
+  VoicemailConfigurationPage,
+};

--- a/packages/manager/apps/freefax/cypress/support/po/freefax/notifications.js
+++ b/packages/manager/apps/freefax/cypress/support/po/freefax/notifications.js
@@ -1,0 +1,17 @@
+import BasePage from '../base';
+
+export default class NotificationsPage extends BasePage {
+  constructor(serviceId) {
+    super();
+
+    this.serviceId = serviceId;
+
+    this.mainSection = 'freefax.notifications:section';
+    this.hashUrl = `#!/freefax/${this.serviceId}/notifications`;
+  }
+
+  goBack() {
+    this.getE2E('freefax.notifications:navigation:back')
+      .click();
+  }
+}

--- a/packages/manager/apps/freefax/cypress/support/po/freefax/voicemailConfiguration.js
+++ b/packages/manager/apps/freefax/cypress/support/po/freefax/voicemailConfiguration.js
@@ -1,0 +1,16 @@
+import BasePage from '../base';
+
+export default class VoicemailConfigurationPage extends BasePage {
+  constructor(serviceId) {
+    super();
+    this.serviceId = serviceId;
+
+    this.mainSection = 'freefax.voicemail-configuration:section';
+    this.hashUrl = `#!/freefax/${this.serviceId}/voicemail`;
+  }
+
+  goBack() {
+    this.getE2E('freefax.voicemail-configuration:navigation:back')
+      .click();
+  }
+}

--- a/packages/manager/apps/freefax/cypress/support/po/index.js
+++ b/packages/manager/apps/freefax/cypress/support/po/index.js
@@ -1,0 +1,7 @@
+import BasePage from './base';
+import FreefaxPage from './freefax';
+
+export default {
+  BasePage,
+  FreefaxPage,
+};

--- a/packages/manager/apps/freefax/index.html
+++ b/packages/manager/apps/freefax/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+    <head>
+        <title>FreeFax App</title>
+    </head>
+    <body data-ng-app="freefaxApp">
+        <div data-ui-view></div>
+    </body>
+</html>

--- a/packages/manager/apps/freefax/index.js
+++ b/packages/manager/apps/freefax/index.js
@@ -1,0 +1,7 @@
+import 'script-loader!jquery'; // eslint-disable-line
+import 'script-loader!lodash'; // eslint-disable-line
+
+import angular from 'angular';
+import '@ovh-ux/manager-freefax';
+
+angular.module('freefaxApp', ['ovhManagerFreeFax']);

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@ovh-ux/manager-freefax-app",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "webpack",
+    "cypress:open": "cypress open",
+    "start": "webpack-dev-server",
+    "test:e2e": "lerna exec --scope @ovh-ux/manager-freefax-app -- node \\$LERNA_ROOT_PATH/scripts/webpack-cypress"
+  },
+  "dependencies": {
+    "@ovh-ux/manager-core": "^1.1.0",
+    "@ovh-ux/manager-freefax": "^1.0.0",
+    "@ovh-ux/manager-telecom-styles": "^2.0.0",
+    "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.2",
+    "@ovh-ux/ovh-angular-contracts": "^3.0.0-beta.0",
+    "@ovh-ux/telecom-universe-components": "^1.3.0",
+    "@uirouter/angularjs": "^1.0.15",
+    "angular": "^1.7.5",
+    "angular-aria": "^1.7.5",
+    "angular-dynamic-locale": "^0.1.37",
+    "angular-i18n": "~1.5.x",
+    "angular-resource": "^1.7.5",
+    "angular-sanitize": "^1.7.5",
+    "angular-translate": "^2.18.1",
+    "angular-translate-loader-pluggable": "^1.3.1",
+    "oclazyload": "^1.1.0",
+    "ovh-angular-apiv7": "^1.2.8",
+    "ovh-angular-http": "^4.0.0-alpha.1",
+    "ovh-angular-sso-auth": "^4.0.0-alpha.2",
+    "ovh-angular-ui-confirm-modal": "^1.0.2",
+    "ovh-api-services": "^3.24.0",
+    "ovh-ui-angular": "^2.21.4",
+    "ovh-ui-kit": "^2.23.1",
+    "ovh-ui-kit-bs": "^2.0.1"
+  },
+  "devDependencies": {
+    "@ovh-ux/manager-webpack-config": "^3.0.0",
+    "cypress": "^3.1.3",
+    "eslint-plugin-cypress": "^2.1.3",
+    "ovh-manager-webfont": "^1.0.2",
+    "webpack-merge": "^4.1.4"
+  }
+}

--- a/packages/manager/apps/freefax/webpack.config.js
+++ b/packages/manager/apps/freefax/webpack.config.js
@@ -1,0 +1,22 @@
+const merge = require('webpack-merge');
+const path = require('path');
+const webpackConfig = require('@ovh-ux/manager-webpack-config');
+
+module.exports = (env = {}) => {
+  const { config } = webpackConfig({
+    template: './index.html',
+    basePath: '.',
+    root: path.resolve(process.cwd()),
+  }, env);
+
+  return merge(config, {
+    entry: path.resolve('./index.js'),
+    resolve: {
+      modules: [
+        path.resolve(process.cwd(), './node_modules'),
+        path.resolve(process.cwd(), '../../../../node_modules'),
+      ],
+      mainFields: ['module', 'browser', 'main'],
+    },
+  });
+};

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -31,6 +31,8 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
     "ovh-api-services": "^3.24.0",
-    "ovh-ui-angular": "^2.21.4"
+    "ovh-ui-angular": "^2.21.4",
+    "ovh-ui-kit": "^2.23.1",
+    "ovh-ui-kit-bs": "^2.0.1"
   }
 }

--- a/packages/manager/modules/freefax/src/credit/index.js
+++ b/packages/manager/modules/freefax/src/credit/index.js
@@ -2,7 +2,7 @@ import angular from 'angular';
 
 import 'ovh-api-services';
 import 'ovh-ui-angular';
-// import 'ovh-angular-contracts';
+import '@ovh-ux/ovh-angular-contracts';
 
 import { DISCRETE_CREDIT } from './freefax-credit.constants';
 import controller from './freefax-credit.controller';

--- a/packages/manager/modules/freefax/src/faxConfiguration/freefax-faxConfiguration.html
+++ b/packages/manager/modules/freefax/src/faxConfiguration/freefax-faxConfiguration.html
@@ -35,6 +35,7 @@
                                 data-translate="freefax_quality">
                         </strong>
                         <span class="oui-tile__description"
+                              data-ng-if="freeFax.faxQuality"
                               data-ng-bind="'freefax_quality_' + freeFax.faxQuality | translate">
                         </span>
                     </div>

--- a/packages/manager/modules/freefax/src/freefax.component.js
+++ b/packages/manager/modules/freefax/src/freefax.component.js
@@ -1,14 +1,14 @@
 
 import angular from 'angular';
 
-import '@ovh-ux/manager-core';
 import '@ovh-ux/telecom-universe-components';
 import '@ovh-ux/manager-telecom-styles';
 import '@ovh-ux/ng-uirouter-title';
 import 'ovh-angular-ui-confirm-modal';
 import 'ovh-api-services';
 
-import '@ovh-ux/ovh-angular-contracts';
+import 'ovh-ui-kit/dist/oui.css';
+import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
 
 import credit from './credit';
 import faxConfiguration from './faxConfiguration';
@@ -23,7 +23,6 @@ import freeFaxInformations from './information/freeFax-information.html';
 export default angular
   .module('OvhManagerFreefaxComponent', [
     'ovh-api-services',
-    'ovhManagerCore',
     'telecomUniverseComponents',
     'ui.router',
     'ovh-angular-ui-confirm-modal',

--- a/packages/manager/modules/freefax/src/freefax.html
+++ b/packages/manager/modules/freefax/src/freefax.html
@@ -1,7 +1,7 @@
 <section
     class="telecom-legacy telecom-freeFax-section"
-    data-ui-view>
-
+    data-ui-view
+    data-e2e-id="freefax:section">
     <div class="telecom-freeFax">
 
         <div class="telecom-section-header">

--- a/packages/manager/modules/freefax/src/index.js
+++ b/packages/manager/modules/freefax/src/index.js
@@ -2,11 +2,14 @@ import angular from 'angular';
 import '@uirouter/angularjs';
 import 'oclazyload';
 
+import '@ovh-ux/manager-core';
+
 const moduleName = 'ovhManagerFreeFax';
 
 angular
   .module(moduleName, [
     'ui.router',
+    'ovhManagerCore',
     'oc.lazyLoad',
   ])
   .config(/* @ngInject */($stateProvider) => {

--- a/packages/manager/modules/freefax/src/information/freeFax-information.html
+++ b/packages/manager/modules/freefax/src/information/freeFax-information.html
@@ -65,7 +65,8 @@
                     </strong>
                     <div class="oui-tile__description">
                         <a class="oui-button oui-button_full-width oui-button_icon-right oui-button_secondary"
-                           data-ui-sref="freefax.notifications">
+                           data-ui-sref="freefax.notifications"
+                           data-e2e-id="freefax:navigation:notifications">
                            <span data-ng-pluralize
                                  data-count="freeFax.voicemail.redirectionEmails.length"
                                  data-when="{
@@ -86,7 +87,8 @@
                     </strong>
                     <div class="oui-tile__description">
                         <a class="oui-button oui-button_full-width oui-button_icon-right oui-button_secondary"
-                           data-ui-sref="freefax.voicemail-configuration">
+                           data-ui-sref="freefax.voicemail-configuration"
+                           data-e2e-id="freefax:navigation:voicemailConfiguration">
                             <span data-ng-if="freeFax.voicemailActive"
                                  data-translate="freefax_voicemail_active">
                             </span>

--- a/packages/manager/modules/freefax/src/notifications/freefax-notifications.html
+++ b/packages/manager/modules/freefax/src/notifications/freefax-notifications.html
@@ -1,7 +1,10 @@
-<section class="telecom-freefax-notifications">
+<section class="telecom-freefax-notifications"
+         data-e2e-id="freefax.notifications:section">
 
     <header>
-        <tuc-section-back-link data-tuc-section-back-link-to-state="freefax"></tuc-section-back-link>
+        <tuc-section-back-link
+            data-tuc-section-back-link-to-state="freefax"
+            data-e2e-id="freefax.notifications:navigation:back"></tuc-section-back-link>
         <h1 data-translate="freefax_notifications_title"
             data-translate-values="{ serviceName: FreefaxNotifications.serviceName }">
         </h1>
@@ -17,7 +20,7 @@
                 data-ng-click="FreefaxNotifications.add()"
                 data-ng-disabled="!FreefaxNotifications.notifications ||
                                   FreefaxNotifications.notifications.length >= FreefaxNotifications.maxNotifications"
-                data-translate-attr="{ title: 'components_notification_add' }">
+                data-translate-attr="{ title: 'freefax_notification_add_title' }">
             <i class="oui-icon oui-icon-add mr-2" aria-hidden="true"></i>
             <span data-translate="freefax_notification_add"></span>
         </button>

--- a/packages/manager/modules/freefax/src/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/freefax/src/translations/Messages_fr_FR.json
@@ -32,6 +32,7 @@
   "freefax_notification_type_simple": "Notification seule",
   "freefax_notification_type_attachment": "Pièce jointe",
   "freefax_notification_add": "Ajouter",
+  "freefax_notification_add_title": "Ajouter une alerte",
   "freefax_notification_delete": "Supprimer cette notification",
   "freefax_notification_confirm": "Voulez-vous vraiment supprimer la notification <strong>{{email}}</strong> ?",
   "freefax_notif_show_none": "Aucun suivi",

--- a/packages/manager/modules/freefax/src/voicemailConfiguration/freefax-voicemailConfiguration.html
+++ b/packages/manager/modules/freefax/src/voicemailConfiguration/freefax-voicemailConfiguration.html
@@ -1,7 +1,10 @@
-<section class="telecom-freefax-voicemail">
+<section class="telecom-freefax-voicemail"
+         data-e2e-id="freefax.voicemail-configuration:section">
 
     <header>
-        <tuc-section-back-link data-tuc-section-back-link-to-state="freefax"></tuc-section-back-link>
+        <tuc-section-back-link
+            data-tuc-section-back-link-to-state="freefax"
+            data-e2e-id="freefax.voicemail-configuration:navigation:back"></tuc-section-back-link>
         <h1 data-translate="freefax_voicemail_configuration_title"
             data-translate-values="{ serviceName: VoicemailConf.serviceName }">
         </h1>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,14 +1969,6 @@ ajv-keywords@^3.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
 ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -2002,7 +1994,7 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-angular-aria@1.7.5:
+angular-aria@1.7.5, angular-aria@^1.7.5:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/angular-aria/-/angular-aria-1.7.5.tgz#e66334d80ad6b4b01f005f590d7c7eef0064312f"
   integrity sha512-X2dGRw+PK7hrV7/X1Ns4e5P3KC/OBFi1l7z//D/v7zbZObsAx48qBoX7unsck+s4+mnO+ikNNkHG5N49VfAyRw==
@@ -2039,7 +2031,7 @@ angular-sanitize@1.3.x:
   resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.3.20.tgz#5b1caa4176b8db2039d7d1c1527537a61be3cd67"
   integrity sha1-WxyqQXa42yA519HBUnU3phvjzWc=
 
-angular-sanitize@1.7.5:
+angular-sanitize@1.7.5, angular-sanitize@^1.7.5:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.7.5.tgz#75d49e15071ca9c70581e76d20940f26372e24d2"
   integrity sha512-wjKCJOIwrkEvfD0keTnKGi6We13gtoCAQIHcdoqyoo3gwvcgNfYymVQIS3+iCGVcjfWz0jHuS3KgB4ysRWsTTA==
@@ -2078,7 +2070,7 @@ angular@1.3.x:
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.3.20.tgz#b23a3d7c5e7f99f7d95b9b4d49b9ac355269baee"
   integrity sha1-sjo9fF5/mffZW5tNSbmsNVJpuu4=
 
-angular@1.7.5, "angular@>=1.2.26 <=1.7", "angular@>=1.3.0 <2.0.0":
+angular@1.7.5, "angular@>=1.2.26 <=1.7", "angular@>=1.3.0 <2.0.0", angular@^1.7.5:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.5.tgz#d1c1c01c6f5dc835638f3f9aa51012857bdac49e"
   integrity sha512-760183yxtGzni740IBTieNuWLtPNAoMqvmC0Z62UoU0I3nqk+VJuO3JbQAXOyvo3Oy/ZsdNQwrSTh/B0OQZjNw==
@@ -5916,11 +5908,6 @@ handlebars@^4.0.2:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-  integrity sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -5930,9 +5917,6 @@ har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   integrity sha1-M0gdDxu/9gDdID11gSpqX7oALio=
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
 
 har-validator@~5.0.3:
   version "5.0.3"
@@ -7122,13 +7106,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
-
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -9215,6 +9192,13 @@ ovh-angular-ui-confirm-modal@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-angular-ui-confirm-modal/-/ovh-angular-ui-confirm-modal-1.0.2.tgz#92e6736588a4fb1de6353f1a17ab1962679a698d"
   integrity sha512-3V17DbzWjUjl9sKCd25Oycn+7eqg6iW+DpizwVmixHFzDNDMnpKSGmxRLrOq+q9YNE7IepoAKWjoSiy2+zOEEg==
 
+ovh-api-services@^3.24.0:
+  version "3.27.1"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.27.1.tgz#4b4de84a07695180a8226798ace5978a8809a2d5"
+  integrity sha512-kTkZm9eFXCuYlNT+ZhK5jM75tMWm0L9nHwVXqLPpBOndT2xTHtwONxiGDbMdrtKvCyLFlXm4MUDPhdsrxHOa0Q==
+  dependencies:
+    lodash "^3.10.1"
+
 "ovh-api-services@https://github.com/ovh-ux/ovh-api-services.git#42cb36c4dbf424bb67efe19a569e3f854ab4b124":
   version "3.24.0"
   resolved "https://github.com/ovh-ux/ovh-api-services.git#42cb36c4dbf424bb67efe19a569e3f854ab4b124"
@@ -9234,7 +9218,7 @@ ovh-ngstrap@^4.0.2:
   resolved "https://registry.yarnpkg.com/ovh-ngstrap/-/ovh-ngstrap-4.0.2.tgz#059291bfb9f59b78df991e476dd2ede0507cb3c9"
   integrity sha1-BZKRv7n1m3jfmR5HbdLt4FB8s8k=
 
-ovh-ui-angular@^2.23.0:
+ovh-ui-angular@^2.21.4, ovh-ui-angular@^2.23.0:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-2.23.0.tgz#5171a8ffa191dde62eca9b6a2ebd6d8cdcb41da9"
   integrity sha512-vbUQ4XWRrUvz9OHjEYin2gkHg8zw4yRXziq1jccxtp8qSPb8+8h2cjKrLdQ6YCmDFJnEiGSwJ7NTz9QpFHcqHA==


### PR DESCRIPTION
## test(freefax): add standalone tests

### Description of the Change

03c6fdd — test(freefax): add standalone tests

* add test with navigation between states in freefax modules
* add tests to check if translations are present when used (`data-translate`and `data-translate-attr` directives and `$translate.instant` call)
* Some `data-e2e-id` in html for tests purpose (see [Cypress Best Practices](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements))
* add missing translations