### PR TITLE
build(deps): move bootstrap as dependency

### DIFF
--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -14,13 +14,14 @@
   ],
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
+  "browser": "./dist/umd/sms.js",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c --watch",
     "prepare": "yarn run build"
   },
-  "browser": "./dist/umd/index.js",
   "dependencies": {
+    "bootstrap4": "twbs/bootstrap#v4.0.0",
     "lodash": "^4.17.11",
     "moment": "^2.22.2"
   },
@@ -35,12 +36,11 @@
     "@uirouter/angularjs": "^1.0.15",
     "angular": "1.7.5",
     "at-internet-ui-router-plugin": "^1.0.0",
-    "bootstrap4": "twbs/bootstrap#v4.0.0",
     "font-awesome": "4.7.0",
     "ng-at-internet": "^3.1.1",
-    "ovh-angular-pagination-front": "^6.0.0",
     "oclazyload": "^1.1.0",
     "ovh-angular-checkbox-table": "^0.1.2",
+    "ovh-angular-pagination-front": "^6.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
     "ovh-manager-webfont": "^1.0.2",


### PR DESCRIPTION
## build(deps): move bootstrap as dependency

### Description of the Change

9f2d6a1 — build(deps): move bootstrap as dependency

/cc @jleveugle @frenautvh @antleblanc

