### PR TITLE
New Release

### DIFF
--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@ovh-ux/manager-core": "^1.2.0",
     "@ovh-ux/manager-telecom-styles": "^2.0.1",
-    "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.1",
+    "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@ovh-ux/telecom-universe-components": "^1.5.1",
     "@uirouter/angularjs": "^1.0.15",

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -27,6 +27,7 @@
   "peerDependencies": {
     "@ovh-ux/manager-core": "^1.2.0",
     "@ovh-ux/manager-telecom-styles": "^2.0.1",
+    "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
     "@ovh-ux/ng-tail-logs": "^2.0.0-beta.0",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@ovh-ux/telecom-universe-components": "^1.5.1",

--- a/packages/manager/modules/overthebox/src/order/index.js
+++ b/packages/manager/modules/overthebox/src/order/index.js
@@ -1,4 +1,6 @@
 import angular from 'angular';
+import '@ovh-ux/ng-ovh-contracts';
+
 import controller from './order-overTheBox.controller';
 import template from './order-overTheBox.html';
 
@@ -8,6 +10,7 @@ const moduleName = 'ovhManagerOtbOrder';
 
 angular
   .module(moduleName, [
+    'ngOvhContracts',
     ovhManagerOtbWarning,
   ])
   .config(($stateProvider) => {

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@ovh-ux/manager-core": "^1.2.0",
     "@ovh-ux/manager-telecom-styles": "^2.0.1",
-    "@ovh-ux/ng-ovh-contracts": "3.0.0-beta.1",
+    "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
     "@ovh-ux/telecom-universe-components": "^1.5.1",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "1.7.5",


### PR DESCRIPTION
## bump @ovh-ux/ng-ovh-contracts dependency

### Description of the Change

* add @ovh-ux/ng-ovh-contracts@^3.0.0-beta.3 as peer dependency
* bump @ovh-ux/ng-ovh-contracts@^3.0.0-beta.3

6f61f65 — fix(overthebox): add missing ng-ovh-contracts dependency
5cdfb1a — fix(deps): bump @ovh-ux/ng-ovh-contracts dependency

/cc @jleveugle @frenautvh @antleblanc