### PR TITLE
fix(overthebox): add serviceName in updateName event

### DIFF
--- a/packages/manager/modules/overthebox/src/overTheBox.controller.js
+++ b/packages/manager/modules/overthebox/src/overTheBox.controller.js
@@ -37,6 +37,7 @@ export default /* @ngInject */ function
 
       $scope.$emit(
         'overTheBox_updateName',
+        self.service.serviceName,
         self.service.customerDescription || self.service.serviceName,
       );
       return str;


### PR DESCRIPTION
## fix(overthebox): add serviceName in updateName event

### Description of the Change

95652b9 — fix(overthebox): add serviceName in updateName event

ref: OM-262

/cc @jleveugle @frenautvh @antleblanc

