### PR TITLE
Fix/dashboard

### DIFF
--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "scripts": {
     "build": "webpack",
-    "start": "webpack-dev-server"
+    "dev": "webpack-dev-server",
+    "dev:watch": "yarn run dev",
+    "start": "lerna exec --stream --scope='@ovh-ux/manager-telecom-dashboard-app' --include-filtered-dependencies -- yarn run build",
+    "start:dev": "lerna exec --stream --scope='@ovh-ux/manager-telecom-dashboard-app' --include-filtered-dependencies -- yarn run dev",
+    "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-telecom-dashboard-app' --include-filtered-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
     "@ovh-ux/manager-core": "^1.2.0",

--- a/packages/manager/modules/telecom-dashboard/package.json
+++ b/packages/manager/modules/telecom-dashboard/package.json
@@ -17,8 +17,12 @@
   "module": "./dist/esm/index.js",
   "browser": "./dist/umd/telecom-dashboard.js",
   "scripts": {
-    "build": "rollup -c",
-    "dev": "rollup -c --watch",
+    "build": "rollup -c --environment BUILD:production",
+    "dev": "rollup -c --environment BUILD:development",
+    "dev:watch": "yarn run dev --watch",
+    "start": "lerna exec --stream --scope='@ovh-ux/manager-telecom-dashboard' --include-filtered-dependencies -- yarn run build",
+    "start:dev": "lerna exec --stream --scope='@ovh-ux/manager-telecom-dashboard' --include-filtered-dependencies -- yarn run dev",
+    "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-telecom-dashboard' --include-filtered-dependencies -- yarn run dev",
     "prepare": "yarn run build"
   },
   "devDependencies": {


### PR DESCRIPTION
Main entry (CJS) is currently not generated because we launch build task in development mode.

CJS & UMD are only generated in production mode. Currently, if you import the package using NPM, main and browser enries are not availables.

Script entries are now linted as others packages, to avoid this issue.