### PR TITLE
build(deps): upgrade ovh-ui-kit and ovh-ui-angular

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -34,8 +34,8 @@
     "ovh-angular-apiv7": "^1.2.8",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
     "ovh-api-services": "^3.24.0",
-    "ovh-ui-angular": "^2.21.4",
-    "ovh-ui-kit": "^2.23.1",
+    "ovh-ui-angular": "^2.24.1",
+    "ovh-ui-kit": "^2.24.1",
     "ovh-ui-kit-bs": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/manager/apps/layout-ovh/package.json
+++ b/packages/manager/apps/layout-ovh/package.json
@@ -82,7 +82,7 @@
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^2.24.1",
-    "ovh-ui-kit": "^2.23.1",
+    "ovh-ui-kit": "^2.24.1",
     "ovh-ui-kit-bs": "^2.1.1",
     "punycode": "^1.2.4",
     "validator-js": "chriso/validator.js#3.40.1"

--- a/packages/manager/apps/private-database/package.json
+++ b/packages/manager/apps/private-database/package.json
@@ -30,8 +30,8 @@
     "font-awesome": "4.7.0",
     "jquery": "^2.1.3",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-ui-angular": "^2.23.0",
-    "ovh-ui-kit": "^2.23.1",
+    "ovh-ui-angular": "^2.24.1",
+    "ovh-ui-kit": "^2.24.1",
     "ovh-ui-kit-bs": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -24,7 +24,7 @@
     "lodash": "^3.10.1",
     "ng-at-internet": "^3.1.1",
     "ovh-manager-webfont": "^1.0.2",
-    "ovh-ui-kit": "^2.23.1",
+    "ovh-ui-kit": "^2.24.1",
     "ovh-ui-kit-bs": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -25,8 +25,8 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^3.24.0",
     "ovh-manager-webfont": "^1.0.2",
-    "ovh-ui-angular": "^2.21.4",
-    "ovh-ui-kit": "^2.23.1",
+    "ovh-ui-angular": "^2.24.1",
+    "ovh-ui-kit": "^2.24.1",
     "ovh-ui-kit-bs": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/manager/modules/telecom-styles/package.json
+++ b/packages/manager/modules/telecom-styles/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/umd/telecom-styles.js",
   "dependencies": {
     "bootstrap": "^3.3.7",
-    "ovh-ui-kit": "^2.23.1",
+    "ovh-ui-kit": "^2.24.1",
     "ovh-ui-kit-bs": "^2.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9425,18 +9425,6 @@ ovh-ngstrap@^4.0.2:
   resolved "https://registry.yarnpkg.com/ovh-ngstrap/-/ovh-ngstrap-4.0.2.tgz#059291bfb9f59b78df991e476dd2ede0507cb3c9"
   integrity sha1-BZKRv7n1m3jfmR5HbdLt4FB8s8k=
 
-ovh-ui-angular@^2.21.4, ovh-ui-angular@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-2.23.0.tgz#5171a8ffa191dde62eca9b6a2ebd6d8cdcb41da9"
-  integrity sha512-vbUQ4XWRrUvz9OHjEYin2gkHg8zw4yRXziq1jccxtp8qSPb8+8h2cjKrLdQ6YCmDFJnEiGSwJ7NTz9QpFHcqHA==
-  dependencies:
-    bloodhound-js "^1.2.3"
-    clipboard "^2.0.1"
-    escape-string-regexp "^1.0.5"
-    flatpickr "^4.5.2"
-    popper.js "^1.14.4"
-    ui-select "^0.19.8"
-
 ovh-ui-angular@^2.24.1:
   version "2.24.1"
   resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-2.24.1.tgz#5c62f88d0dc496eac1cb44a7492783458bd42adc"
@@ -9454,10 +9442,17 @@ ovh-ui-kit-bs@^2.0.1, ovh-ui-kit-bs@^2.1.1:
   resolved "https://registry.yarnpkg.com/ovh-ui-kit-bs/-/ovh-ui-kit-bs-2.1.1.tgz#bf9c5b035041797091b1a4c50f759bef7501dcef"
   integrity sha512-gjWYjnGmS75nrEpYoYIvJ/wh7K8zzm4k5x2+mICOCmEOKbU7iWy642iXxvDI1TYR+61TDTRjtshnXsGVtUtu7g==
 
-ovh-ui-kit@^2.22.0, ovh-ui-kit@^2.23.1:
+ovh-ui-kit@^2.22.0:
   version "2.23.1"
   resolved "https://registry.yarnpkg.com/ovh-ui-kit/-/ovh-ui-kit-2.23.1.tgz#4c3a3980575d693b33a1d5d056c210be0ba67376"
   integrity sha512-i2/S0A/agP27DxiMHf6Y+ueMQpQU8j5YJkVq0uW0+1gFV228VaesCZezSeOH6XFTChAzPSJS79nuAvIFvo48Fw==
+  dependencies:
+    less-plugin-remcalc "^0.1.0"
+
+ovh-ui-kit@^2.24.1:
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/ovh-ui-kit/-/ovh-ui-kit-2.24.1.tgz#d56c8cbc7881655a9124b2300c3e1acea32c93e9"
+  integrity sha512-KlPg4dq1NqEEncAdlE5nGfihD16tfaRlyWiAJNhIpbZD/xfmSQchM5x39Y40kldatUR9t3HXch8D3dQ2e80ioA==
   dependencies:
     less-plugin-remcalc "^0.1.0"
 
@@ -9887,9 +9882,9 @@ pluralize@^7.0.0:
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
 popper.js@^1.14.4:
-  version "1.14.6"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.6.tgz#ab20dd4edf9288b8b3b6531c47c361107b60b4b0"
-  integrity sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA==
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.7.tgz#e31ec06cfac6a97a53280c3e55e4e0c860e7738e"
+  integrity sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==
 
 portfinder@^1.0.9:
   version "1.0.20"


### PR DESCRIPTION
# Upgrade dependencies

### ⬆️ `ovh-ui-kit@^2.24.1` and `ovh-ui-angular@^2.24.1`

uses: yarn upgrade-interactive --latest
- ovh-ui-angular@^2.24.1
- ovh-ui-kit@^2.24.1

Prevent having a warning message:
```txt
@ovh-ux/manager-layout-ovh: ovh-ui-angular
@ovh-ux/manager-layout-ovh:   Multiple versions of ovh-ui-angular found:
@ovh-ux/manager-layout-ovh:     2.23.0 /Users/aleblanc/Code/github/ovh-ux/manager/~/ovh-ui-angular
@ovh-ux/manager-layout-ovh:     2.24.1 ./~/ovh-ui-angular
@ovh-ux/manager-layout-ovh: Check how you can resolve duplicate packages:
@ovh-ux/manager-layout-ovh: https://github.com/darrenscerri/duplicate-package-checker-webpack-plugin#resolving-duplicate-packages-in-your-bundle
```