### PR TITLE
build(deps): upgrade ovh-api-services

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -33,7 +33,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-apiv7": "^1.2.8",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^3.24.0",
+    "ovh-api-services": "^3.33.0",
     "ovh-ui-angular": "^2.24.1",
     "ovh-ui-kit": "^2.24.1",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/apps/layout-ovh/package.json
+++ b/packages/manager/apps/layout-ovh/package.json
@@ -78,7 +78,7 @@
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-swimming-poll": "^3.0.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "https://github.com/ovh-ux/ovh-api-services.git#42cb36c4dbf424bb67efe19a569e3f854ab4b124",
+    "ovh-api-services": "^3.33.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^2.24.1",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -31,7 +31,7 @@
     "ovh-angular-pagination-front": "^7.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^3.31.0"
+    "ovh-api-services": "^3.33.0"
   },
   "devDependencies": {
     "@ovh-ux/manager-webpack-config": "^3.0.1",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -23,7 +23,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^3.24.0",
+    "ovh-api-services": "^3.33.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-angular": "^2.24.1",
     "ovh-ui-kit": "^2.24.1",

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -37,7 +37,7 @@
     "angular-translate": "^2.18.1",
     "angular-translate-loader-pluggable": "^1.3.1",
     "ovh-angular-apiv7": "^1.2.8",
-    "ovh-api-services": "^3.18.0",
+    "ovh-api-services": "^3.33.0",
     "ovh-ui-angular": "^2.24.1"
   }
 }

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -35,7 +35,7 @@
     "angular-translate": "^2.18.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^3.24.0",
+    "ovh-api-services": "^3.33.0",
     "ovh-ui-angular": "^2.21.4",
     "ovh-ui-kit": "^2.23.1",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -49,7 +49,7 @@
     "ovh-angular-pagination-front": "^6.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^3.31.0",
+    "ovh-api-services": "^3.33.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.23.1",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -33,7 +33,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^3.24.0",
+    "ovh-api-services": "^3.33.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-angular": "^2.21.4",
     "ovh-ui-kit": "^2.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9404,16 +9404,12 @@ ovh-angular-ui-confirm-modal@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-angular-ui-confirm-modal/-/ovh-angular-ui-confirm-modal-1.0.2.tgz#92e6736588a4fb1de6353f1a17ab1962679a698d"
   integrity sha512-3V17DbzWjUjl9sKCd25Oycn+7eqg6iW+DpizwVmixHFzDNDMnpKSGmxRLrOq+q9YNE7IepoAKWjoSiy2+zOEEg==
 
-ovh-api-services@^3.24.0, ovh-api-services@^3.31.0:
-  version "3.31.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.31.0.tgz#b4b50dd8816b36b9266c6362c922b6c3fdda8996"
-  integrity sha512-ngb65X6BEBvR+dFYKdu8wgEKqKwFY1WFQGiJQoavQ1H0xEilAiURwkVXCpTUVufTA17fqdM1Ob4IY8WraQ6eAQ==
+ovh-api-services@^3.33.0:
+  version "3.33.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.33.0.tgz#ac4dc6a4f025530fb1f2116a4550f5d544b373d2"
+  integrity sha512-pVno5PB6ohnrm6uOPJLBoaf8NmPjfhHmn0PyzdBKAqiPc12w93Q1XOFJU5vaBw24rUMvD7NG3H0+iRdZsafyNg==
   dependencies:
     lodash "^3.10.1"
-
-"ovh-api-services@https://github.com/ovh-ux/ovh-api-services.git#42cb36c4dbf424bb67efe19a569e3f854ab4b124":
-  version "3.24.0"
-  resolved "https://github.com/ovh-ux/ovh-api-services.git#42cb36c4dbf424bb67efe19a569e3f854ab4b124"
 
 ovh-manager-webfont@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
# Upgrade dependencies

### ⬆️ `ovh-api-services@^3.33.0`

uses: yarn upgrade-interactive --latest
- ovh-api-services@3.33.0

Prevent having a warning message:
```txt
@ovh-ux/manager-layout-ovh:  warning
@ovh-ux/manager-layout-ovh: ovh-api-services
@ovh-ux/manager-layout-ovh:   Multiple versions of ovh-api-services found:
@ovh-ux/manager-layout-ovh:     3.24.0 /Users/aleblanc/Code/github/ovh-ux/manager/~/@ovh-ux/ng-ovh-otrs/~/ovh-api-services
@ovh-ux/manager-layout-ovh:     3.31.0 /Users/aleblanc/Code/github/ovh-ux/manager/~/ovh-api-services
@ovh-ux/manager-layout-ovh: Check how you can resolve duplicate packages:
@ovh-ux/manager-layout-ovh: https://github.com/darrenscerri/duplicate-package-checker-webpack-plugin#resolving-duplicate-packages-in-your-bundle
```