### PR TITLE
fix(sidebar.constants): set right sms state reference

### DIFF
--- a/packages/manager/apps/layout-ovh/src/sidebar/sidebar.constants.js
+++ b/packages/manager/apps/layout-ovh/src/sidebar/sidebar.constants.js
@@ -196,7 +196,7 @@ export const STATE_MAPPING_SERVICE = {
     },
   },
   '/sms/{serviceName}': {
-    state: 'sms.dashboard',
+    state: 'sms.service.dashboard',
     stateParams: {
       serviceName: 'resource.name',
     },


### PR DESCRIPTION
# Set right sms state reference

### 🐛 Bug Fix

9f87c76 — fix(sidebar.constants): set right sms state reference