### PR TITLE
build(split): add split script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "yarn lint && yarn run test:e2e",
     "test:e2e": "lerna run test:e2e --stream --concurrency=1",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
-    "release": "node ./scripts/release"
+    "release": "node ./scripts/release",
+    "split": "scripts/split.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.1.1",
@@ -39,11 +40,13 @@
     "execa": "^1.0.0",
     "find-free-port": "^2.0.0",
     "git-raw-commits": "^2.0.0",
+    "git-url-parse": "^11.1.2",
     "htmlhint": "^0.10.0",
     "husky": "^1.0.0",
     "kill-port": "^1.3.2",
     "lerna": "^3.4.3",
     "lint-staged": "^7.2.2",
+    "lodash": "^4.17.11",
     "npm-run-all": "^4.1.5",
     "octonode": "^0.9.5",
     "ora": "^3.0.0",

--- a/scripts/split.js
+++ b/scripts/split.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const execa = require('execa');
+const gitUrlParse = require('git-url-parse');
+const ora = require('ora');
+const path = require('path');
+const program = require('commander');
+const find = require('lodash/find');
+const kebabCase = require('lodash/kebabCase');
+
+const getBranchUrl = async (branch) => {
+  const { stdout: remoteUrl } = await execa('git', ['config', '--get', 'remote.origin.url']);
+  const gitHttpsUrl = gitUrlParse(remoteUrl).toString('https');
+  return `git+${gitHttpsUrl}#${branch}`;
+};
+
+const getCurrentBranch = () => execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+  .then(({ stdout: branchName }) => branchName);
+
+const getPackageInfos = name => execa('lerna', ['list', '-la', '--json'])
+  .then(({ stdout: packageList }) => {
+    const searchPackage = find(JSON.parse(packageList), { name });
+    if (!searchPackage) {
+      return Promise.reject(new Error(`"${name}" package not found`));
+    }
+    if (searchPackage.private) {
+      return Promise.reject(new Error(`"${searchPackage.name}" is a private package`));
+    }
+    return searchPackage;
+  });
+
+const getSubtreeBranch = (packageName, currentBranch) => {
+  const [scope, name] = packageName.split('/');
+  const leftPart = name || scope;
+  return `split-${leftPart}/${kebabCase(currentBranch)}`;
+};
+
+const subtreeSplit = (prefix, branch) => execa('git', ['subtree', 'split', `--prefix=${prefix}`, `--branch=${branch}`]);
+
+const pushBranch = branch => execa('git', ['push', 'origin', branch]);
+
+const subtreePush = (prefix, remote, branch) => execa('git', ['subtree', 'push', `--prefix=${prefix}`, remote, branch]);
+
+const split = async (packageName, { branch, remote, push }) => {
+  let spinner = ora('Search Package infos').start();
+
+  try {
+    const packageInfos = await getPackageInfos(packageName);
+    const currentBranch = await getCurrentBranch();
+    spinner.succeed();
+
+    const branchName = branch
+      || (remote ? currentBranch : getSubtreeBranch(packageInfos.name, currentBranch));
+    const prefix = path.relative(process.cwd(), packageInfos.location);
+
+    if (!remote) {
+      spinner = ora(`Create subtree branch "${branchName}" from "${packageName}" package (${prefix})`).start();
+      await subtreeSplit(prefix, branchName);
+      spinner.succeed();
+
+      if (push) {
+        spinner = ora(`Pushing "${branchName}" to origin`).start();
+        await pushBranch(branchName);
+        spinner.succeed();
+      }
+
+      console.log('🎉  And now, you should:\n');
+      if (!push) {
+        console.log(`📤  push your branch:
+  git push origin ${branchName}
+`);
+      }
+      const url = await getBranchUrl(branchName);
+      console.log(`📦  use the splitted branch in your repository:
+  yarn add ${url}
+`);
+    } else {
+      spinner = ora(`Create remote subtree branch "${branchName}" from "${packageName}" package (${prefix}) on ${remote}`).start();
+      await subtreePush(prefix, remote, branchName);
+      spinner.succeed();
+    }
+  } catch (error) {
+    spinner.fail();
+    console.error(error.message);
+  }
+};
+
+program
+  .description('Generate a subtree branch (from the current one) for the specified package')
+  .usage('[options] <packageName>')
+  .option('-b, --branch [branch]', 'set a custom branch name')
+  .option('-p, --push', 'push the splitted branch to origin (useless with "remote" option)')
+  .option('-r, --remote [remote]', 'remote url (like git@github.com:ovh-ux/manager.git)')
+  .on('--help', () => {
+    console.log(`
+Examples:
+
+  * Split a module:
+    $ split @ovh-ux/manager-core
+
+  * Split a module and push the subtree branch:
+    $ split @ovh-ux/manager-core --push
+
+  * Split a module and specify a branch name:
+    $ split @ovh-ux/manager-core --branch manager-core/split
+
+  * Split a module and push it to another repository:
+    $ split @ovh-ux/manager-core --remote git@github.com:ovh-ux/manager.git
+    `);
+  })
+  .action(() => {
+    const [packageName] = program.args;
+    if (packageName) {
+      split(
+        packageName,
+        {
+          branch: program.branch || false,
+          push: program.push,
+          remote: program.remote || false,
+        },
+      );
+    } else {
+      program.outputHelp();
+    }
+  })
+  .parse(process.argv);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5827,6 +5827,21 @@ git-semver-tags@^2.0.2:
     meow "^4.0.0"
     semver "^5.5.0"
 
+git-up@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
+  integrity sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==
+  dependencies:
+    is-ssh "^1.3.0"
+    parse-url "^5.0.0"
+
+git-url-parse@^11.1.2:
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.1.2.tgz#aff1a897c36cc93699270587bea3dbcbbb95de67"
+  integrity sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==
+  dependencies:
+    git-up "^4.0.0"
+
 gitconfiglocal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz#41d045f3851a5ea88f03f24ca1c6178114464b9b"
@@ -7027,6 +7042,13 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
   integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
+
+is-ssh@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.1.tgz#f349a8cadd24e65298037a522cf7520f2e81a0f3"
+  integrity sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==
+  dependencies:
+    protocols "^1.1.0"
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
@@ -8891,6 +8913,11 @@ normalize-selector@^0.2.0:
   resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
   integrity sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=
 
+normalize-url@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
+  integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
@@ -9589,6 +9616,24 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
+parse-path@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-4.0.1.tgz#0ec769704949778cb3b8eda5e994c32073a1adff"
+  integrity sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==
+  dependencies:
+    is-ssh "^1.3.0"
+    protocols "^1.4.0"
+
+parse-url@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
+  integrity sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==
+  dependencies:
+    is-ssh "^1.3.0"
+    normalize-url "^3.3.0"
+    parse-path "^4.0.0"
+    protocols "^1.4.0"
+
 parserlib@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parserlib/-/parserlib-1.1.1.tgz#a64cfa724062434fdfc351c9a4ec2d92b94c06f4"
@@ -10037,6 +10082,11 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+protocols@^1.1.0, protocols@^1.4.0:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.7.tgz#95f788a4f0e979b291ffefcf5636ad113d037d32"
+  integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
 
 protoduck@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## build(split): add split script

### Description of the Change

```sh
Usage: split [options] <packageName>
Generate a subtree branch (from the current one) for the specified package
Options:
  -b, --branch [branch]  set a custom branch name
  -p, --push             push the created splitted branch to origin (useless with "remote" option)
  -r, --remote [remote]  remote url (like git@github.com:ovh-ux/manager.git)
```

### Example 

From a `test-split` branch 
```bash
$ git rev-parse --abbrev-ref HEAD
test-split
$ yarn split @ovh-ux/manager-core --push
yarn run v1.12.3
$ node ./scripts/split @ovh-ux/manager-core --push
✔ Search Package infos
✔ Create subtree branch "split-manager-core/test-split" from "@ovh-ux/manager-core" package (packages/manager/modules/core)
✔ Pushing "split-manager-core/test-split" to origin
🎉  And now, you should :

📦  use the splitted branch in your repository :
  yarn add git+https://github.com/ovh-ux/manager.git#split-manager-core/test-split
✨  Done in 7.84s.
````
produces a `split-manager-core/test-split` branch : https://github.com/ovh-ux/manager/tree/split-manager-core/test-split 




872ddb1 — build(split): add split script

/cc @jleveugle @frenautvh @antleblanc

