### PR TITLE
build(deps): upgrade eslint-import-resolver-lerna to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "conventional-recommended-bump": "^4.0.4",
     "eslint": "^5.8.0",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-import-resolver-lerna": "jleveugle/eslint-import-resolver-lerna",
+    "eslint-import-resolver-lerna": "^1.1.0",
     "execa": "^1.0.0",
     "find-free-port": "^2.0.0",
     "git-raw-commits": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4790,9 +4790,10 @@ eslint-config-airbnb-base@^13.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-import-resolver-lerna@jleveugle/eslint-import-resolver-lerna:
-  version "1.0.0"
-  resolved "https://codeload.github.com/jleveugle/eslint-import-resolver-lerna/tar.gz/5e503982d70aa23bffd13a97bb6e757657767537"
+eslint-import-resolver-lerna@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-lerna/-/eslint-import-resolver-lerna-1.1.0.tgz#4069a41742651de953ea1063a455aec952388a69"
+  integrity sha512-4olD03ngUo7Q7yRuOF5Gb9WxOc+CLEnw+rt95TnjUWQJ4pn0h9XWSybAr2gswOhre0NHXwwhAhPE8CAiwISFyw==
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"


### PR DESCRIPTION
# ⬆️ Upgrade `eslint-import-resolver-lerna`

### ⚙️ Build

5266ed4 - build(deps): upgrade eslint-import-resolver-lerna to v1.1.0

ref: https://github.com/Dreamscapes/eslint-import-resolver-lerna/releases/tag/1.1.0