### PR TITLE
build(scripts): extends eslint configuration

### DIFF
--- a/scripts/.eslintrc.json
+++ b/scripts/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc.js",
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -10,7 +10,7 @@ execa.shell('lerna ls -pl --json')
           .then(output => Object.assign(pkg, { publish: output.stdout.length > 0 }))
           .catch((err) => {
             if (!err.stderr.includes('404')) {
-              console.error(err); // eslint-disable-line
+              console.error(err);
               process.exit(1);
             }
             return Object.assign(pkg, { publish: false });

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 const program = require('commander');
 const {
   checkChanges, getChangedRepositories, bumpRepositories,

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 const ora = require('ora');
 const { Codename, Sample } = require('@ovh-ux/codename-generator');
 const { MonoRepository } = require('../common/repository');

--- a/scripts/split.js
+++ b/scripts/split.js
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable no-console */
-
 const execa = require('execa');
 const gitUrlParse = require('git-url-parse');
 const ora = require('ora');

--- a/scripts/webpack-cypress.js
+++ b/scripts/webpack-cypress.js
@@ -15,5 +15,5 @@ fp(3000, (err, port) => {
     })
     .then(() => kill(port))
     .then(() => process.exit(0))
-    .catch((err) => { console.error(err); process.exit(1); }); // eslint-disable-line
+    .catch((err) => { console.error(err); process.exit(1); }); // eslint-disable-line no-shadow
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1667,13 +1667,6 @@
     bootstrap "^3.3.7"
     ovh-ui-kit "^2.22.0"
 
-"@ovh-ux/ng-ovh-user-pref@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-user-pref/-/ng-ovh-user-pref-1.0.0.tgz#fd5035855e09758de6f5e886bff78011f44bd0f9"
-  integrity sha512-EmVfYGu8zjjqOfh/R7a291sswbpcbtt2IEmGAorETgUMZIB/CnAQvD5ELzf4NseUJHjG6G0W9HFyJ6u9jkFJRA==
-  dependencies:
-    lodash "^4.17.11"
-
 "@ovh-ux/ng-pagination-front@^8.0.0-alpha.0":
   version "8.0.0-alpha.0"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ng-pagination-front/-/ng-pagination-front-8.0.0-alpha.0.tgz#fd84086d04068734cebb2a3e216a8db9116a0d7b"


### PR DESCRIPTION
# Extends ESLint configuration

### :gear: Build

962c82c - build(scripts): extends eslint configuration

turn off the `no-console` rule which is quite often use