### PR TITLE
style: use single quote for scss files

### DIFF
--- a/packages/manager/apps/layout-ovh/src/manager-layout-ovh.scss
+++ b/packages/manager/apps/layout-ovh/src/manager-layout-ovh.scss
@@ -1,11 +1,4 @@
-@import "~bootstrap4/scss/_functions";
-@import "~bootstrap4/scss/_variables";
-@import "~bootstrap4/scss/_mixins";
-@import '~bootstrap4/scss/_utilities.scss';
-
-// Microsoft Icons
-// @import './../../../node_modules/office-ui-fabric-react/dist/sass/variables/_Icon.Variables.scss';
-// @import './../../../node_modules/office-ui-fabric-react/dist/sass/variables/_ZIndex.Variables.scss';
-// @import './../../../node_modules/office-ui-fabric-react/dist/sass/mixins/_Icon.Mixins.scss';
-// @import './../../../node_modules/office-ui-fabric-react/dist/sass/_Icon.Definitions.scss';
-// @import './../../../node_modules/office-ui-fabric-react/dist/sass/_Icon.scss';
+@import '~bootstrap4/scss/_functions';
+@import '~bootstrap4/scss/_variables';
+@import '~bootstrap4/scss/_mixins';
+@import '~bootstrap4/scss/_utilities';

--- a/packages/manager/apps/public-cloud/src/index.scss
+++ b/packages/manager/apps/public-cloud/src/index.scss
@@ -1,4 +1,4 @@
-@import "~bootstrap4/scss/_functions";
-@import "~bootstrap4/scss/_variables";
-@import "~bootstrap4/scss/_mixins";
-@import '~bootstrap4/scss/_utilities.scss';
+@import '~bootstrap4/scss/_functions';
+@import '~bootstrap4/scss/_variables';
+@import '~bootstrap4/scss/_mixins';
+@import '~bootstrap4/scss/_utilities';

--- a/packages/manager/modules/freefax/src/freefax.scss
+++ b/packages/manager/modules/freefax/src/freefax.scss
@@ -1,6 +1,6 @@
 .telecom-freefax-section {
-  @import "~bootstrap4/scss/_functions";
-  @import "~bootstrap4/scss/_variables";
-  @import "~bootstrap4/scss/_mixins";
-  @import "~bootstrap4/scss/_utilities.scss";
+  @import '~bootstrap4/scss/_functions';
+  @import '~bootstrap4/scss/_variables';
+  @import '~bootstrap4/scss/_mixins';
+  @import '~bootstrap4/scss/_utilities';
 }

--- a/packages/manager/modules/kubernetes/src/details/index.scss
+++ b/packages/manager/modules/kubernetes/src/details/index.scss
@@ -1,7 +1,7 @@
-ovh-manager-kubernetes-detail-component{
-  @import "~bootstrap4/scss/_functions";
-  @import "~bootstrap4/scss/_variables";
-  @import "~bootstrap4/scss/_mixins";
-  @import '~bootstrap4/scss/_utilities.scss';
-  @import '~bootstrap4/scss/_grid.scss';
+ovh-manager-kubernetes-detail-component { /* stylelint-disable-line */
+  @import '~bootstrap4/scss/_functions';
+  @import '~bootstrap4/scss/_variables';
+  @import '~bootstrap4/scss/_mixins';
+  @import '~bootstrap4/scss/_utilities';
+  @import '~bootstrap4/scss/_grid';
 }

--- a/packages/manager/modules/kubernetes/src/list/index.scss
+++ b/packages/manager/modules/kubernetes/src/list/index.scss
@@ -1,7 +1,7 @@
-ovh-manager-kubernetes-list{
-  @import "~bootstrap4/scss/_functions";
-  @import "~bootstrap4/scss/_variables";
-  @import "~bootstrap4/scss/_mixins";
-  @import '~bootstrap4/scss/_utilities.scss';
-  @import '~bootstrap4/scss/_grid.scss';
+ovh-manager-kubernetes-list { /* stylelint-disable-line */
+  @import '~bootstrap4/scss/_functions';
+  @import '~bootstrap4/scss/_variables';
+  @import '~bootstrap4/scss/_mixins';
+  @import '~bootstrap4/scss/_utilities';
+  @import '~bootstrap4/scss/_grid';
 }

--- a/packages/manager/modules/overthebox/src/overTheBox.scss
+++ b/packages/manager/modules/overthebox/src/overTheBox.scss
@@ -1,6 +1,6 @@
 ovh-manager-over-the-box-component { /* stylelint-disable-line */
-  @import "~bootstrap4/scss/_functions";
-  @import "~bootstrap4/scss/_variables";
-  @import "~bootstrap4/scss/_mixins";
-  @import '~bootstrap4/scss/_utilities.scss';
+  @import '~bootstrap4/scss/_functions';
+  @import '~bootstrap4/scss/_variables';
+  @import '~bootstrap4/scss/_mixins';
+  @import '~bootstrap4/scss/_utilities';
 }

--- a/packages/manager/modules/pci/src/index.scss
+++ b/packages/manager/modules/pci/src/index.scss
@@ -1,7 +1,7 @@
 .cloud-pci-section {
-  @import "~bootstrap4/scss/_functions";
-  @import "~bootstrap4/scss/_variables";
-  @import "~bootstrap4/scss/_mixins";
-  @import "~bootstrap4/scss/_utilities";
-  @import "~bootstrap4/scss/_grid";
+  @import '~bootstrap4/scss/_functions';
+  @import '~bootstrap4/scss/_variables';
+  @import '~bootstrap4/scss/_mixins';
+  @import '~bootstrap4/scss/_utilities';
+  @import '~bootstrap4/scss/_grid';
 }

--- a/packages/manager/modules/sms/src/telecom-sms.scss
+++ b/packages/manager/modules/sms/src/telecom-sms.scss
@@ -1,6 +1,6 @@
 .telecom-sms {
-  @import "~bootstrap4/scss/_functions";
-  @import "~bootstrap4/scss/_variables";
-  @import "~bootstrap4/scss/_mixins";
-  @import "~bootstrap4/scss/_utilities.scss";
+  @import '~bootstrap4/scss/_functions';
+  @import '~bootstrap4/scss/_variables';
+  @import '~bootstrap4/scss/_mixins';
+  @import '~bootstrap4/scss/_utilities';
 }

--- a/packages/manager/modules/telecom-dashboard/src/telecom-dashboard.scss
+++ b/packages/manager/modules/telecom-dashboard/src/telecom-dashboard.scss
@@ -1,6 +1,6 @@
 .telecom-dashboard {
-  @import "~bootstrap4/scss/_functions";
-  @import "~bootstrap4/scss/_variables";
-  @import "~bootstrap4/scss/_mixins";
-  @import '~bootstrap4/scss/_utilities.scss';
+  @import '~bootstrap4/scss/_functions';
+  @import '~bootstrap4/scss/_variables';
+  @import '~bootstrap4/scss/_mixins';
+  @import '~bootstrap4/scss/_utilities';
 }


### PR DESCRIPTION
# Use single quote for `scss` files

### 💄 Styles

- removed some extra `.scss` from import statements.
- turn off some lines in order to prevent stylelint error

### 🏠 Internal

- No QC required