### PR TITLE
refactor(apps.vrack): imports module name with reference

### DIFF
--- a/packages/manager/apps/vrack/index.js
+++ b/packages/manager/apps/vrack/index.js
@@ -1,7 +1,7 @@
 import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!lodash'; // eslint-disable-line
-import '@ovh-ux/manager-vrack';
 
 import angular from 'angular';
+import ovhManagerVrack from '@ovh-ux/manager-vrack';
 
-angular.module('vrackApp', ['ovhManagerVrack']);
+angular.module('vrackApp', [ovhManagerVrack]);


### PR DESCRIPTION
# Imports module name with reference

### 💅 Refactor

62eb7a7 - refactor(apps.vrack): imports module name with reference

since `@ovh-ux/manager-vrack` is a dependency it have to be imported in 
that way in order to be aligned with `README.md` instructions

ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Syntax

### 🏠 Internal

- No QC required