### PR TITLE
build(apps.vrack): remove repository entry from package.json file

### DIFF
--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -2,11 +2,6 @@
   "name": "@ovh-ux/manager-vrack-app",
   "version": "0.1.0",
   "private": true,
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ovh-ux/manager.git",
-    "directory": "packages/manager/app/vrack"
-  },
   "scripts": {
     "build": "webpack",
     "dev": "webpack-dev-server",


### PR DESCRIPTION
# Remove `repository` entry from `package.json` file

### ⚙️ Build

6b960da - build(apps.vrack): remove repository entry from package.json file

since this package is set to be private, there is no benefit of 
providing a `repository` entry.

### 🏠 Internal

- No QC required