### PR TITLE
build(apps.kubernetes): set right init version number

### DIFF
--- a/packages/manager/apps/kubernetes/CHANGELOG.md
+++ b/packages/manager/apps/kubernetes/CHANGELOG.md
@@ -1,9 +1,6 @@
-# [3.1.0](https://github.com/ovh-ux/manager/compare/@ovh-ux/manager-kubernetes-app@3.0.0...@ovh-ux/manager-kubernetes-app@3.1.0) (2019-03-22)
+# [1.0.0](https://github.com/ovh-ux/manager/compare/@ovh-ux/manager-kubernetes-app@0.0.0...@ovh-ux/manager-kubernetes-app@1.0.0) (2019-03-22)
 
 
 ### Features
 
 * **kubernetes:** init module ([#319](https://github.com/ovh-ux/manager/issues/319)) ([5281031](https://github.com/ovh-ux/manager/commit/5281031))
-
-
-

--- a/packages/manager/apps/kubernetes/package.json
+++ b/packages/manager/apps/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovh-ux/manager-kubernetes-app",
-  "version": "3.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "build": "webpack",


### PR DESCRIPTION
# Set right init version number

### ⚙️ Build

47f62d4 - build(apps.kubernetes): set right init version number

- packages/manager/apps/kubernetes/CHANGELOG.md has also been updated manually

### 🏠 Internal

- No QC required