### PR TITLE
Build/bump api services

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -34,7 +34,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.7.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-ui-angular": "^2.21.4",
     "ovh-ui-kit": "^2.23.1",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/apps/kubernetes/package.json
+++ b/packages/manager/apps/kubernetes/package.json
@@ -24,7 +24,7 @@
     "angular": "^1.7.5",
     "angular-ui-bootstrap": "^1.3.3",
     "font-awesome": "^4.7.0",
-    "ovh-api-services": "^6.7.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-ui-angular": "~2.25.1",
     "ovh-ui-kit": "~2.25.0"
   },

--- a/packages/manager/apps/layout-ovh/package.json
+++ b/packages/manager/apps/layout-ovh/package.json
@@ -71,7 +71,7 @@
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.7.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^2.23.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -51,7 +51,7 @@
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
     "ovh-angular-responsive-page-switcher": "^1.1.0",
-    "ovh-api-services": "^6.7.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-common-style": "^5.0.0",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "^1.1.0",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -31,7 +31,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.7.0"
+    "ovh-api-services": "^6.8.0"
   },
   "devDependencies": {
     "@ovh-ux/manager-webpack-config": "^3.0.1",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -24,7 +24,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.7.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-angular": "^2.21.4",
     "ovh-ui-kit": "^2.23.1",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -29,7 +29,7 @@
     "jquery": "^2.1.3",
     "lodash": "^3.10.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^4.2.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-angular": "^2.24.2",
     "ovh-ui-kit": "~2.25.0"

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -48,7 +48,7 @@
     "angular-translate": "^2.11.0",
     "angular-ui-bootstrap": "~1.3.3",
     "d3": "~3.5.13",
-    "ovh-api-services": "^6.1.2",
+    "ovh-api-services": "^6.8.0",
     "ovh-ui-angular": "^2.24.2"
   }
 }

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -44,7 +44,7 @@
     "angular-sanitize": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-translate-loader-pluggable": "^1.3.1",
-    "ovh-api-services": "^6.1.2",
+    "ovh-api-services": "^6.8.0",
     "ovh-ui-angular": "^2.23.0"
   }
 }

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -40,7 +40,7 @@
     "angular-translate": "^2.18.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.1.2",
+    "ovh-api-services": "^6.8.0",
     "ovh-ui-angular": "^2.21.4",
     "ovh-ui-kit": "^2.23.1",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/kubernetes/package.json
+++ b/packages/manager/modules/kubernetes/package.json
@@ -40,7 +40,7 @@
     "angular-ui-bootstrap": "^1.3.3",
     "font-awesome": "^4.7.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.2.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-ui-angular": "~2.24.0",
     "ovh-ui-kit": "~2.24.0"
   },

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -61,7 +61,7 @@
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
     "ovh-angular-responsive-page-switcher": "^1.1.0",
-    "ovh-api-services": "^5.0.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-common-style": "^5.0.0",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "^1.1.0",

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -55,7 +55,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.1.2",
+    "ovh-api-services": "^6.8.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.23.1",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -38,7 +38,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.1.2",
+    "ovh-api-services": "^6.8.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-angular": "^2.21.4",
     "ovh-ui-kit": "^2.23.1",

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -48,6 +48,7 @@
     "angular-ui-bootstrap": "~1.3.3",
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
+    "ovh-api-services": "^6.8.0",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-kit": "~2.24.0",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/vrack/src/vrack.component.js
+++ b/packages/manager/modules/vrack/src/vrack.component.js
@@ -1,6 +1,8 @@
 import angular from 'angular';
 import '@ovh-ux/ng-ovh-contracts';
 
+import 'ovh-api-services';
+
 import controller from './vrack.controller';
 import template from './vrack.html';
 import vrackService from './vrack.service';
@@ -21,6 +23,7 @@ const moduleName = 'OvhManagerVrackComponent';
 
 angular
   .module(moduleName, [
+    'ovh-api-services',
     'ui.router',
     'ngOvhContracts',
   ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -9316,17 +9316,10 @@ ovh-angular-ui-confirm-modal@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-angular-ui-confirm-modal/-/ovh-angular-ui-confirm-modal-1.0.2.tgz#92e6736588a4fb1de6353f1a17ab1962679a698d"
   integrity sha512-3V17DbzWjUjl9sKCd25Oycn+7eqg6iW+DpizwVmixHFzDNDMnpKSGmxRLrOq+q9YNE7IepoAKWjoSiy2+zOEEg==
 
-ovh-api-services@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-4.2.0.tgz#6b85f990aefae1fbf5233718f856aa051dab98c5"
-  integrity sha512-IippIziLZplEJe6kX8SCZaaR7lLYm+iFbleL/G8x7zMkQeHDIwmKAiHWgAubXXoMyj/GgigBGlrYHiK8eNRAqg==
-  dependencies:
-    lodash "^3.10.1"
-
-ovh-api-services@^6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.7.0.tgz#b65fa6c22e2d4e37100f5747e57f96d929cee446"
-  integrity sha512-r7LBjFBIJvpPQrI+r95nUsW57wGfLt+b9yhnLRE6/iuC5ga0g+0CJuIuD7m5U5vjMbfL+EyyQkF/MsKSVn2fAA==
+ovh-api-services@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.8.0.tgz#9c1d533a906bac9130b5750c875b86a6cc8469a7"
+  integrity sha512-RluVliGpb5lQdXqaHQTHd86eFv7yxutcntPiJsOQ7WwMsGojZuUvwpCvHIN18J71VoTGjP+yxbY6EdMI5lOLVw==
   dependencies:
     lodash "^3.10.1"
 


### PR DESCRIPTION
# Bump ovh-api-services to v6.8.0

* Use `yarn upgrade-interactive --latest ovh-api-services`
* Add `ovh-api-services` as a peer dependency for `vrack` module