### PR TITLE
fix(navbar.language-menu): remove sk from constants

### DIFF
--- a/packages/manager/modules/navbar/src/language-menu/constants.js
+++ b/packages/manager/modules/navbar/src/language-menu/constants.js
@@ -14,7 +14,6 @@ export const LANGUAGES = [
   { value: 'nl_NL', name: 'Nederlands' },
   { value: 'pl_PL', name: 'Polski' },
   { value: 'pt_PT', name: 'Português' },
-  { value: 'sk_SK', name: 'Slovakian' },
   { value: 'fi_FI', name: 'Suomi' },
   { value: 'cs_CZ', name: 'Česky' },
 ];


### PR DESCRIPTION
# Remove `sk_SK` from constants

### 🐛 Bug Fix

6027c9e - fix(navbar.language-menu): remove sk from constants

### 🏠 Internal

- No QC required

### 🔗 Related

- ovh-ux/ovh-manager-web#692
- ovh-ux/ovh-manager-dedicated#1045