### PR TITLE
build(apps.public-cloud): remove resolve.symlinks from webpack config

### DIFF
--- a/packages/manager/apps/public-cloud/webpack.config.js
+++ b/packages/manager/apps/public-cloud/webpack.config.js
@@ -22,7 +22,6 @@ module.exports = (env = {}) => {
         path.resolve(__dirname, '../../../node_modules'),
       ],
       mainFields: ['module', 'browser', 'main'],
-      symlinks: false,
     },
     optimization: {
       splitChunks: {


### PR DESCRIPTION
# Remove resolve.symlinks from webpack config

### ⚙️ Build

d07ecfb - build(apps.public-cloud): remove resolve.symlinks from webpack config

### 🏠 Internal

- No QC required

---

Prevent to have this following error from the console:

```js
angular.js:138 Uncaught Error: [$injector:modulerr] Failed to instantiate module ovhStack due to:
Error: [$injector:modulerr] Failed to instantiate module {} due to:
Error: [ng:areq] Argument 'module' is not a function, got Object
```

🔖 Note: The module must be also renamed.