### PR TITLE
Public cloud translations

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/instance/backup/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/backup/translations/Messages_fr_FR.json
@@ -2,7 +2,7 @@
   "pci_projects_project_instances_instance_backup_title": "Création d'un backup",
   "pci_projects_project_instances_instance_backup_name_label": "Saisissez le nom de votre backup :",
   "pci_projects_project_instances_instance_backup_warning_message": "Votre instance sera suspendue pendant quelques secondes, puis les performances en lecture/écriture du disque pourront être affectées jusqu'à la finalisation du backup.",
-  "pci_projects_project_instances_instance_backup_price":  "({{ size }}, soit environ {{ price }} HT/mois)",
+  "pci_projects_project_instances_instance_backup_price": "({{ size }}, soit environ {{ price }} HT/mois)",
   "pci_projects_project_instances_instance_backup_submit_label": "Confirmer",
   "pci_projects_project_instances_instance_backup_cancel_label": "Annuler",
 

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/translations/Messages_fr_FR.json
@@ -2,7 +2,7 @@
   "pci_projects_project_storages_blocks_block_snapshot_title": "Création d'un snapshot de volume",
   "pci_projects_project_storages_blocks_block_snapshot_name_label": "Saisissez le nom de votre snapshot :",
   "pci_projects_project_storages_blocks_block_snapshot_warning_attached": "Votre volume est actuellement attaché à une instance. Pour garantir l'intégrité de vos données, nous vous conseillons de détacher ce disque avant d'effectuer un snapshot.",
-  "pci_projects_project_storages_blocks_block_snapshot_monthly_price":  "({{ size }} x {{ price }} HT/Gio/mois)",
+  "pci_projects_project_storages_blocks_block_snapshot_monthly_price": "({{ size }} x {{ price }} HT/Gio/mois)",
   "pci_projects_project_storages_blocks_block_snapshot_submit_label": "Créer le snapshot",
   "pci_projects_project_storages_blocks_block_snapshot_cancel_label": "Annuler",
 


### PR DESCRIPTION
# Remove extra space in translations file

### 🎏 Translations

e674522 - fix(pci.instance.backup): remove extra space in translations file
51b65aa - fix(pci.storage.block.snapshot): remove extra space in translations file

### 🏠 Internal

- No QC required.