### PR TITLE
refactor(apps.public-cloud): remove extra ng-uirouter-loading component

### DIFF
--- a/packages/manager/apps/public-cloud/src/index.html
+++ b/packages/manager/apps/public-cloud/src/index.html
@@ -7,7 +7,6 @@
     </head>
     <body class="ovhstack h-100" style="overflow: hidden;">
         <div data-ng-app="ovhStack" data-ng-strict-di class="h-100 d-flex flex-column overflow-hidden" data-ng-controller="PublicCloudController as $ctrl">
-            <ng-uirouter-loading></ng-uirouter-loading>
             <div>
                 <ovh-manager-navbar></ovh-manager-navbar>
             </div>


### PR DESCRIPTION
# Remove extra ng-uirouter-loading component

This component has been added when both components `breadcrumb` and `progress` were created.

### 💅 Refactor

6ae9773 - refactor(apps.public-cloud): remove extra ng-uirouter-loading component

### 🏠 Internal

- No QC required.

ref: #374