### PR TITLE
build(components): remove extra dependency from uirouter-line-progress

### DIFF
--- a/packages/components/ng-ovh-uirouter-line-progress/package.json
+++ b/packages/components/ng-ovh-uirouter-line-progress/package.json
@@ -29,7 +29,6 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-uirouter-line-progress' --include-filtered-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
     "nprogress": "^0.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7462,17 +7462,6 @@ less@^3.8.1:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/less/-/less-3.9.0.tgz#b7511c43f37cf57dc87dffd9883ec121289b1474"
   integrity sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==
-  dependencies:
-    clone "^2.1.2"
-  optionalDependencies:
-    errno "^0.1.1"
-    graceful-fs "^4.1.2"
-    image-size "~0.5.0"
-    mime "^1.4.1"
-    mkdirp "^0.5.0"
-    promise "^7.1.1"
-    request "^2.83.0"
-    source-map "~0.6.0"
 
 leven@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Remove extra dependency

### ⚙️ Build

de5e08a - build(components): remove extra dependency from uirouter-line-progress

### 🏠 Internal

- No QC required.