### PR TITLE
fix: update block storages list

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/add/add.controller.js
@@ -142,17 +142,12 @@ export default class PciBlockStorageAddController {
     this.loadings.save = true;
 
     return this.PciProjectStorageBlockService.add(this.projectId, this.storage)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_add_success_message',
-            { volume: this.storage.name },
-          ),
-          'pci.projects.project.storages.blocks',
-        );
-
-        return this.goBack(true);
-      })
+      .then(() => this.goBack(
+        this.$translate.instant(
+          'pci_projects_project_storages_blocks_add_success_message',
+          { volume: this.storage.name },
+        ),
+      ))
       .catch((err) => {
         this.CucCloudMessage.error(
           this.$translate.instant(

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/add/add.routing.js
@@ -4,14 +4,7 @@ export default /* @ngInject */ ($stateProvider) => {
       url: '/new',
       component: 'pciProjectStorageBlocksAdd',
       resolve: {
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_blocks_refresh');
-          }
-          return $state.go('pci.projects.project.storages.blocks', {
-            projectId,
-          });
-        },
+        goBack: /* @ngInject */ goToBlockStorage => goToBlockStorage,
         cancelLink: /* @ngInject */ ($state, projectId) => $state.href('pci.projects.project.storages.blocks', {
           projectId,
         }),

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/attach.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/attach.component.js
@@ -7,6 +7,8 @@ export default {
   bindings: {
     projectId: '<',
     storageId: '<',
+    storage: '<',
+    instances: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/attach.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/attach.controller.js
@@ -6,101 +6,43 @@ export default class PciBlockStorageDetailsAttachController {
   /* @ngInject */
   constructor(
     $translate,
-    CucCloudMessage,
     PciProjectStorageBlockService,
   ) {
     this.$translate = $translate;
-    this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageBlockService = PciProjectStorageBlockService;
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
+    this.isLoading = false;
 
-    return this.initLoaders();
+    this.instancesList = map(
+      this.instances,
+      ({ id, name }) => ({ id, name }),
+    );
   }
 
-  initLoaders() {
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageBlockService.get(this.projectId, this.storageId))
-      .then((storage) => {
-        this.storage = storage;
-        return this.PciProjectStorageBlockService
-          .getCompatiblesInstances(this.projectId, this.storage);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_attach_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-        );
-      })
-      .then((instances) => {
-        this.instances = instances;
-        this.instancesList = map(
-          this.instances,
-          ({ id, name }) => ({ id, name }),
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    return new Promise((resolve) => {
-      this.CucCloudMessage.unSubscribe('pci.projects.project.storages.blocks.attach');
-      this.messageHandler = this.CucCloudMessage.subscribe(
-        'pci.projects.project.storages.blocks.attach',
-        {
-          onMessage: () => this.refreshMessages(),
-        },
-      );
-      resolve();
-    });
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
-  }
 
   attachStorage({ id, name: instanceName }) {
-    this.loadings.save = true;
+    this.isLoading = true;
     const instance = find(this.instances, { id });
 
     return this.PciProjectStorageBlockService
       .attachTo(this.projectId, this.storage, instance)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_attach_success_message',
-            {
-              volume: this.storage.name,
-              instance: instanceName,
-            },
-          ),
-          'pci.projects.project.storages.blocks',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_attach_error_attach',
-            {
-              message: get(err, 'data.message', null),
-            },
-          ),
-        );
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_attach_success_message',
+        {
+          volume: this.storage.name,
+          instance: instanceName,
+        },
+      )))
+      .catch(err => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_attach_error_attach',
+        {
+          message: get(err, 'data.message', null),
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/attach.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/attach.html
@@ -2,13 +2,11 @@
     data-heading="{{:: 'pci_projects_project_storages_blocks_block_attach_title' | translate}}"
     data-primary-action="$ctrl.attachStorage($ctrl.selectedInstance)"
     data-primary-label="{{:: 'pci_projects_project_storages_blocks_block_attach_submit_label' | translate }}"
-    data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save || !$ctrl.selectedInstance"
+    data-primary-disabled="$ctrl.isLoading || !$ctrl.selectedInstance"
     data-secondary-action="$ctrl.goBack()"
     data-secondary-label="{{:: 'pci_projects_project_storages_blocks_block_attach_cancel_label' | translate }}"
     data-on-dismiss="$ctrl.goBack()"
-    data-loading="$ctrl.loadings.init">
-
-    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+    data-loading="$ctrl.isLoading">
 
     <div data-ng-if="$ctrl.instancesList.length === 0">
         <oui-message data-type="warning">
@@ -23,12 +21,7 @@
             data-items="$ctrl.instancesList"
             data-match="name"
             data-searchable
-            data-disabled="$ctrl.loadings.save">
+            data-disabled="$ctrl.isLoading">
         </oui-select>
     </div>
-
-    <div data-ng-if="$ctrl.loadings.save" class="text-center">
-        <oui-spinner></oui-spinner>
-    </div>
-
 </oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/attach.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/attach.routing.js
@@ -10,14 +10,17 @@ export default /* @ngInject */($stateProvider) => {
       layout: 'modal',
       resolve: {
         storageId: /* @ngInject */$transition$ => $transition$.params().storageId,
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_blocks_refresh');
-          }
-          $state.go('pci.projects.project.storages.blocks', {
-            projectId,
-          });
-        },
+        storage: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+          storageId,
+        ) => PciProjectStorageBlockService.get(projectId, storageId),
+        instances: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+          storage,
+        ) => PciProjectStorageBlockService.getCompatiblesInstances(projectId, storage),
+        goBack: /* @ngInject */ goToBlockStorage => goToBlockStorage,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/attach/translations/Messages_fr_FR.json
@@ -5,7 +5,6 @@
   "pci_projects_project_storages_blocks_block_attach_error_no_compatible_instance": "Vous ne possédez actuellement aucune instance compatible à laquelle attacher ce volume.",
   "pci_projects_project_storages_blocks_block_attach_instance_placeholder": "Rechercher",
   "pci_projects_project_storages_blocks_block_attach_success_message": "Le volume {{ volume }} a été attaché à l'instance {{ instance }}.",
-  "pci_projects_project_storages_blocks_block_attach_error_load": "Une erreur est survenue lors du chargement du volume : {{ message }}",
   "pci_projects_project_storages_blocks_block_attach_error_attach": "Une erreur est survenue lors de la mise à jour du volume {{ volume }} : {{ message }}"
 
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/block.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/block.module.js
@@ -7,11 +7,7 @@ import 'oclazyload';
 import 'ovh-ui-angular';
 import 'ovh-api-services';
 
-import blockAttach from './attach';
-import blockDetach from './detach';
-import blockDelete from './delete';
 import blockEdit from './edit';
-import blockSnapshot from './snapshot';
 
 import routing from './block.routing';
 
@@ -19,11 +15,7 @@ const moduleName = 'ovhManagerPciStoragesBlocksBlock';
 
 angular
   .module(moduleName, [
-    blockAttach,
-    blockDetach,
-    blockDelete,
     blockEdit,
-    blockSnapshot,
     'ui.router',
     'oc.lazyLoad',
     'oui',

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/delete.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/delete.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     projectId: '<',
     storageId: '<',
+    storage: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/delete.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/delete.controller.js
@@ -4,89 +4,34 @@ export default class PciBlockStorageDetailsDeleteController {
   /* @ngInject */
   constructor(
     $translate,
-    CucCloudMessage,
     PciProjectStorageBlockService,
   ) {
     this.$translate = $translate;
-    this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageBlockService = PciProjectStorageBlockService;
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
-
-    this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageBlockService.get(this.projectId, this.storageId))
-      .then((storage) => {
-        this.storage = storage;
-        return this.storage;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_delete_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    return new Promise((resolve) => {
-      this.CucCloudMessage.unSubscribe('pci.projects.project.storages.blocks.delete');
-      this.messageHandler = this.CucCloudMessage.subscribe(
-        'pci.projects.project.storages.blocks.delete',
-        {
-          onMessage: () => this.refreshMessages(),
-        },
-      );
-      resolve();
-    });
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
+    this.isLoading = false;
   }
 
   deleteStorage() {
-    this.loadings.save = true;
+    this.isLoading = true;
     return this.PciProjectStorageBlockService.delete(this.projectId, this.storage)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_delete_success_message',
-            {
-              volume: this.storage.name,
-            },
-          ),
-          'pci.projects.project.storages.blocks',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_delete_error_delete',
-            {
-              message: get(err, 'data.message', null),
-            },
-          ),
-        );
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_delete_success_message',
+        {
+          volume: this.storage.name,
+        },
+      )))
+      .catch(err => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_delete_error_delete',
+        {
+          message: get(err, 'data.message', null),
+          volume: this.storage.name,
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/delete.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/delete.html
@@ -2,13 +2,11 @@
     data-heading="{{ 'pci_projects_project_storages_blocks_block_delete_title' | translate }}"
     data-primary-action="$ctrl.deleteStorage()"
     data-primary-label="{{:: 'pci_projects_project_storages_blocks_block_delete_submit_label' | translate }}"
-    data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save || !$ctrl.storage.isDeletable()"
+    data-primary-disabled="$ctrl.isLoading || !$ctrl.storage.isDeletable()"
     data-secondary-action="$ctrl.goBack()"
     data-secondary-label="{{:: 'pci_projects_project_storages_blocks_block_delete_cancel_label' | translate }}"
     data-on-dismiss="$ctrl.goBack()"
-    data-loading="$ctrl.loadings.init">
-
-    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+    data-loading="$ctrl.isLoading">
 
     <div data-ng-if="$ctrl.storage.isDeletable()">
         <p data-translate="pci_projects_project_storages_blocks_block_delete_content"
@@ -19,18 +17,18 @@
     </div>
     <div data-ng-if="!$ctrl.storage.isDeletable()">
         <oui-message data-type="warning">
-            <p data-translate="pci_projects_project_storages_blocks_block_delete_error_should"></p>
-            <ul>
-                <li data-ng-if="!$ctrl.storage.isAttachable()"
-                    data-translate="pci_projects_project_storages_blocks_block_delete_error_detach"></li>
-                <li data-ng-if="$ctrl.storage.hasSnapshots()"
-                    data-translate="pci_projects_project_storages_blocks_block_delete_error_delete_snapshots"></li>
-            </ul>
+            <div data-ng-if="!$ctrl.storage.isAttachable() && $ctrl.storage.hasSnapshots()">
+                <span data-translate="pci_projects_project_storages_blocks_block_delete_error_should_multiple"></span>
+                <ul>
+                    <li data-translate="pci_projects_project_storages_blocks_block_delete_error_detach"></li>
+                    <li data-translate="pci_projects_project_storages_blocks_block_delete_error_delete_snapshots"></li>
+                </ul>
+            </div>
+            <span data-translate="pci_projects_project_storages_blocks_block_delete_error_should_detach"
+                data-ng-if="!$ctrl.storage.isAttachable() && !$ctrl.storage.hasSnapshots()"></span>
+            <span data-translate="pci_projects_project_storages_blocks_block_delete_error_should_snapshots"
+                data-ng-if="$ctrl.storage.isAttachable() && $ctrl.storage.hasSnapshots()"></span>
         </oui-message>
-    </div>
-
-    <div data-ng-if="$ctrl.loadings.save" class="text-center">
-        <oui-spinner></oui-spinner>
     </div>
 
 </oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/delete.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/delete.routing.js
@@ -10,14 +10,12 @@ export default /* @ngInject */($stateProvider) => {
       layout: 'modal',
       resolve: {
         storageId: /* @ngInject */$transition$ => $transition$.params().storageId,
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_blocks_refresh');
-          }
-          return $state.go('pci.projects.project.storages.blocks', {
-            projectId,
-          });
-        },
+        storage: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+          storageId,
+        ) => PciProjectStorageBlockService.get(projectId, storageId),
+        goBack: /* @ngInject */ goToBlockStorage => goToBlockStorage,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/delete/translations/Messages_fr_FR.json
@@ -5,10 +5,14 @@
   "pci_projects_project_storages_blocks_block_delete_content": "Supprimer définitivement le volume {{ volume }}",
   "pci_projects_project_storages_blocks_block_delete_erase_message": "Toutes les données sur le volume seront perdues.",
 
-  "pci_projects_project_storages_blocks_block_delete_error_load": "Une erreur est survenue lors du chargement du volume : {{ message }}",
-  "pci_projects_project_storages_blocks_block_delete_error_should": "Avant de pouvoir supprimer ce volume, vous devez d'abord :",
-  "pci_projects_project_storages_blocks_block_delete_error_detach": "détacher le volume de son instance",
-  "pci_projects_project_storages_blocks_block_delete_error_delete_snapshots": "supprimer les snapshots liés à ce volume",
+  "pci_projects_project_storages_blocks_block_delete_error_should_multiple": "Avant de pouvoir supprimer ce volume, vous devez d'abord :",
+  "pci_projects_project_storages_blocks_block_delete_error_detach": "détacher le volume de son instance,",
+  "pci_projects_project_storages_blocks_block_delete_error_delete_snapshots": "supprimer les snapshots liés à ce volume.",
+
+  "pci_projects_project_storages_blocks_block_delete_error_should_detach": "Avant de pouvoir supprimer ce volume, vous devez d'abord détacher le volume de son instance.",
+  "pci_projects_project_storages_blocks_block_delete_error_should_snapshots": "Avant de pouvoir supprimer ce volume, vous devez d'abord supprimer les snapshots liés à ce volume.",
+
+
   "pci_projects_project_storages_blocks_block_delete_success_message": "Le volume {{ volume }} a été supprimé",
   "pci_projects_project_storages_blocks_block_delete_error_delete": "Une erreur est survenue lors de la suppression du volume {{ volume }} : {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/detach.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/detach.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     projectId: '<',
     storageId: '<',
+    storage: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/detach.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/detach.controller.js
@@ -4,92 +4,35 @@ export default class PciBlockStorageDetailsDetachController {
   /* @ngInject */
   constructor(
     $translate,
-    CucCloudMessage,
     PciProjectStorageBlockService,
   ) {
     this.$translate = $translate;
-    this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageBlockService = PciProjectStorageBlockService;
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
-
-    return this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageBlockService.get(this.projectId, this.storageId))
-      .then((storage) => {
-        this.storage = storage;
-        return this.storage;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_detach_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    return new Promise((resolve) => {
-      this.CucCloudMessage.unSubscribe('pci.projects.project.storages.blocks.detach');
-      this.messageHandler = this.CucCloudMessage.subscribe(
-        'pci.projects.project.storages.blocks.detach',
-        {
-          onMessage: () => this.refreshMessages(),
-        },
-      );
-      resolve();
-    });
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
+    this.isLoading = false;
   }
 
   detachStorage() {
-    this.CucCloudMessage.flushChildMessage('pci.projects.project.storages.blocks');
-
-    this.loadings.save = true;
+    this.isLoading = true;
     return this.PciProjectStorageBlockService
       .detach(this.projectId, this.storage)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_detach_success_message',
-            {
-              volume: this.storage.name,
-            },
-          ),
-          'pci.projects.project.storages.blocks',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_detach_error_delete',
-            {
-              message: get(err, 'data.message', null),
-            },
-          ),
-        );
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_detach_success_message',
+        {
+          volume: this.storage.name,
+        },
+      )))
+      .catch(err => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_detach_error_detach',
+        {
+          message: get(err, 'data.message', null),
+          volume: this.storage.name,
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/detach.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/detach.html
@@ -2,24 +2,18 @@
     data-heading="{{:: 'pci_projects_project_storages_blocks_block_detach_title' | translate }}"
     data-primary-action="$ctrl.detachStorage()"
     data-primary-label="{{:: 'pci_projects_project_storages_blocks_block_detach_submit_label' | translate }}"
-    data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save || !$ctrl.storage.isDetachable()"
+    data-primary-disabled="$ctrl.isLoading || !$ctrl.storage.isDetachable()"
     data-secondary-action="$ctrl.goBack()"
     data-secondary-label="{{:: 'pci_projects_project_storages_blocks_block_detach_cancel_label' | translate }}"
     data-on-dismiss="$ctrl.goBack()"
-    data-loading="$ctrl.loadings.init">
+    data-loading="$ctrl.isLoading">
 
-    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
-
-    <div data-ng-if="!$ctrl.loadings.init"
+    <div
         data-translate="pci_projects_project_storages_blocks_block_detach_detachvolume"
         data-translate-values="{
             volume: $ctrl.storage.name,
             instance: $ctrl.storage.attachedTo[0].name
         }">
-    </div>
-
-    <div data-ng-if="$ctrl.loadings.save" class="text-center">
-        <oui-spinner></oui-spinner>
     </div>
 
 </oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/detach.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/detach.routing.js
@@ -10,14 +10,12 @@ export default /* @ngInject */($stateProvider) => {
       layout: 'modal',
       resolve: {
         storageId: /* @ngInject */$transition$ => $transition$.params().storageId,
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_blocks_refresh');
-          }
-          return $state.go('pci.projects.project.storages.blocks', {
-            projectId,
-          });
-        },
+        storage: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+          storageId,
+        ) => PciProjectStorageBlockService.get(projectId, storageId),
+        goBack: /* @ngInject */ goToBlockStorage => goToBlockStorage,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/translations/Messages_fr_FR.json
@@ -5,5 +5,5 @@
   "pci_projects_project_storages_blocks_block_detach_cancel_label": "Annuler",
 
   "pci_projects_project_storages_blocks_block_detach_success_message": "Le volume {{ volume }} a été détaché",
-  "pci_projects_project_storages_blocks_block_detach_error_detach": "Une erreur est survenue lors de lamise à jour du volume {{ volume }} : {{ message }}"
+  "pci_projects_project_storages_blocks_block_detach_error_detach": "Une erreur est survenue lors de la mise à jour du volume {{ volume }} : {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/detach/translations/Messages_fr_FR.json
@@ -4,7 +4,6 @@
   "pci_projects_project_storages_blocks_block_detach_submit_label": "Confirmer",
   "pci_projects_project_storages_blocks_block_detach_cancel_label": "Annuler",
 
-  "pci_projects_project_storages_blocks_block_detach_error_load": "Une erreur est survenue lors du chargement du volume : {{ message }}",
   "pci_projects_project_storages_blocks_block_detach_success_message": "Le volume {{ volume }} a été détaché",
-  "pci_projects_project_storages_blocks_block_detach_error_delete": "Une erreur est survenue lors de la suppression du volume {{ volume }} : {{ message }}"
+  "pci_projects_project_storages_blocks_block_detach_error_detach": "Une erreur est survenue lors de lamise à jour du volume {{ volume }} : {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     projectId: '<',
     storageId: '<',
+    storage: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.controller.js
@@ -19,26 +19,23 @@ export default class PciBlockStorageDetailsEditController {
   }
 
   $onInit() {
-    this.initLoaders();
-  }
+    this.isLoading = false;
 
-  initLoaders() {
-    this.loading = true;
-
-    this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.getStorage())
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_edit_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-        );
-      })
-      .finally(() => {
-        this.loading = false;
-      });
+    this.editStorage = new BlockStorage(
+      pick(
+        this.storage,
+        [
+          'id',
+          'region',
+          'type',
+          'name',
+          'size',
+          'bootable',
+          'planCode',
+        ],
+      ),
+    );
+    this.loadMessages();
   }
 
   loadMessages() {
@@ -55,44 +52,14 @@ export default class PciBlockStorageDetailsEditController {
     this.messages = this.messageHandler.getMessages();
   }
 
-  getStorage() {
-    return this.PciProjectStorageBlockService
-      .get(this.projectId, this.storageId)
-      .then((storage) => {
-        this.storage = storage;
-
-        this.editStorage = new BlockStorage(
-          pick(
-            this.storage,
-            [
-              'id',
-              'region',
-              'type',
-              'name',
-              'size',
-              'bootable',
-              'planCode',
-            ],
-          ),
-        );
-        return this.editStorage;
-      });
-  }
-
   edit() {
+    this.isLoading = true;
     return this.PciProjectStorageBlockService
       .update(this.projectId, this.editStorage, this.storage)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_edit_success_message',
-            { volume: this.editStorage.name },
-          ),
-          'pci.projects.project.storages.blocks',
-        );
-
-        return this.goBack(true);
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_edit_success_message',
+        { volume: this.editStorage.name },
+      )))
       .catch((err) => {
         this.CucCloudMessage.error(
           this.$translate.instant(
@@ -101,6 +68,9 @@ export default class PciBlockStorageDetailsEditController {
           ),
           'pci.projects.project.storages.blocks.block.edit',
         );
+      })
+      .finally(() => {
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.html
@@ -1,9 +1,7 @@
-<div data-ng-if="$ctrl.loading" class="text-center">
+<div data-ng-if="$ctrl.isLoading" class="text-center">
     <oui-spinner></oui-spinner>
 </div>
-<section data-ng-if="!$ctrl.loading">
-    <oui-back-button
-        data-on-click="$ctrl.goBack()">{{:: 'pci_projects_project_storages_blocks_block_edit_back_label' | translate }}</oui-back-button>
+<section data-ng-if="!$ctrl.isLoading">
 
     <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
 

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.routing.js
@@ -4,14 +4,7 @@ export default /* @ngInject */($stateProvider) => {
       url: '/edit',
       component: 'pciProjectStorageBlocksBlockEdit',
       resolve: {
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_blocks_refresh');
-          }
-          return $state.go('pci.projects.project.storages.blocks', {
-            projectId,
-          });
-        },
+        goBack: /* @ngInject */ goToBlockStorage => goToBlockStorage,
         breadcrumb: /* @ngInject */ $translate => $translate
           .refresh()
           .then(() => $translate.instant('pci_projects_project_storages_blocks_block_edit_title')),

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/translations/Messages_fr_FR.json
@@ -1,5 +1,4 @@
 {
-  "pci_projects_project_storages_blocks_block_edit_back_label": "Retour",
   "pci_projects_project_storages_blocks_block_edit_title": "Editer un volume",
 
   "pci_projects_project_storages_blocks_block_edit_submit_label": "Modifier le volume",

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/snapshot.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/snapshot.component.js
@@ -7,6 +7,8 @@ export default {
   bindings: {
     projectId: '<',
     storageId: '<',
+    storage: '<',
+    priceEstimation: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/snapshot.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/snapshot.controller.js
@@ -5,100 +5,40 @@ export default class PciBlockStorageDetailchsSnapshotController {
   constructor(
     $filter,
     $translate,
-    CucCloudMessage,
     PciProjectStorageBlockService,
   ) {
     this.$filter = $filter;
     this.$translate = $translate;
-    this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageBlockService = PciProjectStorageBlockService;
   }
 
   $onInit() {
     this.snapshot = {};
     this.priceEstimation = null;
-    this.loadings = {
-      init: false,
-      save: false,
-    };
+    this.isLoading = false;
 
-    return this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageBlockService.get(this.projectId, this.storageId))
-      .then((storage) => {
-        this.storage = storage;
-        this.snapshot.name = `${this.storage.name} ${this.$filter('date')(new Date(), 'short')}`;
-        return this.storage;
-      })
-      .then(() => this.PciProjectStorageBlockService
-        .getSnapshotPriceEstimation(this.projectId, this.storage))
-      .then((price) => {
-        this.priceEstimation = price;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_snapshot_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    return new Promise((resolve) => {
-      this.CucCloudMessage.unSubscribe('pci.projects.project.storages.blocks.snapshot');
-      this.messageHandler = this.CucCloudMessage.subscribe(
-        'pci.projects.project.storages.blocks.snapshot',
-        {
-          onMessage: () => this.refreshMessages(),
-        },
-      );
-      resolve();
-    });
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
+    this.snapshot.name = `${this.storage.name} ${this.$filter('date')(new Date(), 'short')}`;
   }
 
   createSnapshot() {
-    this.loadings.save = true;
+    this.isLoading = true;
     return this.PciProjectStorageBlockService
       .createSnapshot(this.projectId, this.storage, this.snapshot)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_snapshot_success_message',
-            {
-              snapshot: this.snapshot.name,
-            },
-          ),
-          'pci.projects.project.storages.blocks',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_blocks_block_snapshot_error_delete',
-            {
-              message: get(err, 'data.message', null),
-              snapshot: this.snapshot.name,
-            },
-          ),
-        );
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_snapshot_success_message',
+        {
+          snapshot: this.snapshot.name,
+        },
+      )))
+      .catch(err => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_blocks_block_snapshot_error_delete',
+        {
+          message: get(err, 'data.message', null),
+          snapshot: this.snapshot.name,
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/snapshot.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/snapshot.html
@@ -7,15 +7,13 @@
         data-heading="{{:: 'pci_projects_project_storages_blocks_block_snapshot_title' | translate }}"
         data-primary-action="$ctrl.detachStorage()"
         data-primary-label="{{:: 'pci_projects_project_storages_blocks_block_snapshot_submit_label' | translate }}"
-        data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save"
+        data-primary-disabled="$ctrl.isLoading"
         data-secondary-action="$ctrl.goBack()"
-        data-secondary-label="{{:: 'pci_projects_project_storages_blocks_block_detach_cancel_label' | translate }}"
+        data-secondary-label="{{:: 'pci_projects_project_storages_blocks_block_snapshot_cancel_label' | translate }}"
         data-on-dismiss="$ctrl.goBack()"
-        data-loading="$ctrl.loadings.init">
+        data-loading="$ctrl.isLoading">
 
-        <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
-
-        <div data-ng-if="!$ctrl.loadings.init">
+        <div data-ng-if="!$ctrl.isLoading">
             <oui-message type="warning" data-ng-if="!$ctrl.storage.isAttachable()">
                 <span data-translate="pci_projects_project_storages_blocks_block_snapshot_warning_attached"></span>
             </oui-message>
@@ -32,7 +30,7 @@
                 data-ng-model="$ctrl.snapshot.name"
                 required
                 data-ng-maxlength="255"
-                data-ng-disabled="$ctrl.loadings.save">
+                data-ng-disabled="$ctrl.isLoading">
 
             <span data-translate="pci_projects_project_storages_blocks_block_snapshot_monthly_price"
                 data-translate-values="{
@@ -40,11 +38,5 @@
                     price: $ctrl.priceEstimation.priceText || '?'
                 }"></span>
         </oui-field>
-
-
-        <div data-ng-if="$ctrl.loadings.save" class="text-center">
-            <oui-spinner></oui-spinner>
-        </div>
-
     </oui-modal>
 </form>

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/snapshot.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/snapshot.routing.js
@@ -10,14 +10,19 @@ export default /* @ngInject */($stateProvider) => {
       layout: 'modal',
       resolve: {
         storageId: /* @ngInject */$transition$ => $transition$.params().storageId,
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_blocks_refresh');
-          }
-          return $state.go('pci.projects.project.storages.blocks', {
-            projectId,
-          });
-        },
+        storage: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+          storageId,
+        ) => PciProjectStorageBlockService.get(projectId, storageId),
+
+        priceEstimation: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+          storage,
+        ) => PciProjectStorageBlockService.getSnapshotPriceEstimation(projectId, storage),
+
+        goBack: /* @ngInject */ goToBlockStorage => goToBlockStorage,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/snapshot/translations/Messages_fr_FR.json
@@ -1,5 +1,5 @@
 {
-  "pci_projects_project_storages_blocks_block_snapshot_title": "Création d'un snapshot de volume",
+  "pci_projects_project_storages_blocks_block_snapshot_title": "Créer un snapshot de volume",
   "pci_projects_project_storages_blocks_block_snapshot_name_label": "Saisissez le nom de votre snapshot :",
   "pci_projects_project_storages_blocks_block_snapshot_warning_attached": "Votre volume est actuellement attaché à une instance. Pour garantir l'intégrité de vos données, nous vous conseillons de détacher ce disque avant d'effectuer un snapshot.",
   "pci_projects_project_storages_blocks_block_snapshot_monthly_price": "({{ size }} x {{ price }} HT/Gio/mois)",

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.component.js
@@ -6,6 +6,7 @@ export default {
   template,
   bindings: {
     projectId: '<',
+    storages: '<',
     addStorage: '<',
     editStorage: '<',
     attachStorage: '<',

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.controller.js
@@ -1,70 +1,36 @@
-import get from 'lodash/get';
-
 import { VOLUME_HELP_PREFERENCE_KEY } from './block.constants';
 
 export default class PciBlockStorageController {
   /* @ngInject */
   constructor(
-    $rootScope,
     $translate,
     CucCloudMessage,
+    CucRegionService,
     ovhUserPref,
     PciProjectStorageBlockService,
   ) {
-    this.$rootScope = $rootScope;
     this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
+    this.CucRegionService = CucRegionService;
     this.ovhUserPref = ovhUserPref;
     this.PciProjectStorageBlockService = PciProjectStorageBlockService;
   }
 
   $onInit() {
-    this.$rootScope.$on('pci_storages_blocks_refresh', () => this.refreshBlocks());
+    this.loadMessages();
     this.initLoaders();
   }
 
   initLoaders() {
     this.loading = true;
     return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.getBlocks())
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          'pci_projects_project_storages_blocks_error_query',
-          { message: get(err, 'data.message', '') },
-        ),
-      ))
       .then(() => this.checkHelpDisplay())
       .finally(() => {
         this.loading = false;
       });
   }
 
-  getBlocks() {
-    return this.PciProjectStorageBlockService
-      .getAll(this.projectId)
-      .then((storages) => {
-        this.storages = storages;
-        return this.storages;
-      });
-  }
-
-  refreshBlocks() {
-    this.loading = true;
-    return this.getBlocks()
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          'pci_projects_project_storages_blocks_error_query',
-          { message: get(err, 'data.message', '') },
-        ),
-      ))
-      .finally(() => {
-        this.loading = false;
-      });
-  }
-
   loadMessages() {
-    this.CucCloudMessage.unSubscribe('pci.projects.project.storages.blocks');
     this.messageHandler = this.CucCloudMessage.subscribe(
       'pci.projects.project.storages.blocks',
       {

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.html
@@ -20,7 +20,9 @@
                 data-property="region"
                 data-type="string"
                 data-sortable
-                data-filterable></oui-column>
+                data-filterable>
+                <span data-ng-bind="$ctrl.CucRegionService.getTranslatedMicroRegion($row.region)"></span>
+            </oui-column>
             <oui-column
                 data-title="'pci_projects_project_storages_blocks_type_label' | translate"
                 data-property="type"

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.module.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ovh-cloud-universe-components';
 import '@ovh-ux/ng-translate-async-loader';
 import '@uirouter/angularjs';
 import 'angular-translate';
@@ -13,6 +14,11 @@ import add from './add';
 import block from './block';
 import help from './help';
 
+import blockAttach from './block/attach';
+import blockDetach from './block/detach';
+import blockDelete from './block/delete';
+import blockSnapshot from './block/snapshot';
+
 import component from './blocks.component';
 import service from './blocks.service';
 
@@ -24,8 +30,13 @@ angular
   .module(moduleName, [
     add,
     block,
+    blockAttach,
+    blockDetach,
+    blockDelete,
+    blockSnapshot,
     help,
     'ngOvhUserPref',
+    'ngOvhCloudUniverseComponents',
     'ngTranslateAsyncLoader',
     'oui',
     'ovh-api-services',

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.routing.js
@@ -32,6 +32,29 @@ export default /* @ngInject */ ($stateProvider) => {
           projectId,
           instanceId,
         }),
+        storages: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+        ) => PciProjectStorageBlockService
+          .getAll(projectId),
+
+        goToBlockStorage: /* @ngInject */ ($rootScope, CucCloudMessage, $state, projectId) => (message = false, type = 'success') => {
+          const reload = message && type === 'success';
+
+          const promise = $state.go('pci.projects.project.storages.blocks', {
+            projectId,
+          },
+          {
+            reload,
+          });
+
+          if (message) {
+            promise.then(() => CucCloudMessage[type](message, 'pci.projects.project.storages.blocks'));
+          }
+
+          return promise;
+        },
+
         breadcrumb: /* @ngInject */ $translate => $translate
           .refresh()
           .then(() => $translate.instant('pci_projects_project_storages_blocks_title')),

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/translations/Messages_fr_FR.json
@@ -22,7 +22,5 @@
   "pci_projects_project_storages_blocks_snapshot_create_label": "Créer un snapshot",
   "pci_projects_project_storages_blocks_delete_label": "Supprimer",
 
-  "pci_projects_project_storages_blocks_add_label": "Créer un volume",
-
-  "pci_projects_project_storages_blocks_error_query": "Une erreur est survenue lors de la récupération des volumes"
+  "pci_projects_project_storages_blocks_add_label": "Créer un volume"
 }


### PR DESCRIPTION
## fix: update block storages list

### Description of the Change

- remove `CucCloudMessage` listener in modals
- add `goToBlockStorage` resolve and use it in `goBack` sub resolve 
  - navigate to block storage list and trigger a `CucCloudMessage`
  - if the message is a `success` message, `$state.go`is called with `reload: true` option
- move initial data loading in `resolve` and remove related code/translations
- Fix translations (wording)
- update `delete` message display (list only if more than 1 message).

4073c5a8 — fix: update block storages list

/cc @jleveugle @marie-j 
