### PR TITLE
fix: update volume snapshots list

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/volume-edit/volume-edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/volume-edit/volume-edit.controller.js
@@ -10,10 +10,12 @@ export default class PciProjectStorageVolumeEditController {
   constructor(
     $timeout,
     $translate,
+    CucRegionService,
     PciProjectStorageBlockService,
   ) {
     this.$timeout = $timeout;
     this.$translate = $translate;
+    this.CucRegionService = CucRegionService;
     this.PciProjectStorageBlockService = PciProjectStorageBlockService;
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/volume-edit/volume-edit.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/volume-edit/volume-edit.html
@@ -13,7 +13,7 @@
         <div class="oui-field oui-field_error">
             <label for="storage-region" class="oui-field__label oui-label"
                 data-translate="pci_projects_project_storages_blocks_block_volume-edit_region_label"></label>
-            <div class="oui-field__control" data-ng-bind="$ctrl.storage.region"></div>
+            <div class="oui-field__control" data-ng-bind="$ctrl.CucRegionService.getTranslatedMicroRegion($ctrl.storage.region)"></div>
         </div>
 
         <div class="oui-field oui-field_error">

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.module.js
@@ -14,7 +14,6 @@ import block from './block';
 import help from './help';
 
 import component from './blocks.component';
-import service from './blocks.service';
 
 import routing from './blocks.routing';
 
@@ -36,7 +35,6 @@ angular
   ])
   .config(routing)
   .component('pciProjectStorageBlocks', component)
-  .service('PciProjectStorageBlockService', service)
   .run(/* @ngTranslationsInject:json ./translations */);
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/index.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import '@uirouter/angularjs';
 import 'oclazyload';
 
+import service from './blocks.service';
+
 const moduleName = 'ovhManagerPciStoragesBlocksLazyLoading';
 
 angular
@@ -19,6 +21,7 @@ angular
           .then(mod => $ocLazyLoad.inject(mod.default || mod));
       },
     });
-  });
+  })
+  .service('PciProjectStorageBlockService', service);
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/index.js
@@ -1,31 +1,24 @@
 import angular from 'angular';
-import '@ovh-ux/ng-translate-async-loader';
 import '@uirouter/angularjs';
-import 'angular-translate';
-import 'ovh-ui-angular';
-import 'ovh-api-services';
+import 'oclazyload';
 
-import snapshot from './snapshot';
-
-import component from './snapshots.component';
-import service from './snapshots.service';
-
-import routing from './snapshots.routing';
-
-const moduleName = 'ovhManagerPciStoragesSnapshots';
+const moduleName = 'ovhManagerPciStoragesSnapshotsLazyLoading';
 
 angular
   .module(moduleName, [
-    'ngTranslateAsyncLoader',
-    'oui',
-    'ovh-api-services',
-    'pascalprecht.translate',
     'ui.router',
-    snapshot,
+    'oc.lazyLoad',
   ])
-  .config(routing)
-  .component('pciProjectStoragesSnapshots', component)
-  .service('PciProjectStorageSnapshotsService', service)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .config(/* @ngInject */($stateProvider) => {
+    $stateProvider.state('pci.projects.project.storages.snapshots.**', {
+      url: '/volume-snapshots',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./snapshots.module')
+          .then(mod => $ocLazyLoad.inject(mod.default || mod));
+      },
+    });
+  });
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     projectId: '<',
     snapshotId: '<',
+    snapshot: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.controller.js
@@ -20,35 +20,25 @@ export default class PciBlockStorageSnapshotsCreateVolumeController {
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
+    this.isLoading = false;
+    this.loadMessages();
 
-    this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loadings.init = true;
-
-    this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.getSnapshot())
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_snapshots_snapshot_create-volume_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
+    this.storage = new BlockStorage({
+      ...pick(
+        this.snapshot,
+        [
+          'region',
+          'name',
+          'size',
+          'bootable',
+        ],
+      ),
+      type: this.snapshot.volume.type,
+      snapshotId: this.snapshot.id,
+    });
   }
 
   loadMessages() {
-    this.CucCloudMessage.unSubscribe('pci.projects.project.storages.snapshots.snapshot.create-volume');
     this.messageHandler = this.CucCloudMessage.subscribe(
       'pci.projects.project.storages.snapshots.snapshot.create-volume',
       {
@@ -61,42 +51,14 @@ export default class PciBlockStorageSnapshotsCreateVolumeController {
     this.messages = this.messageHandler.getMessages();
   }
 
-  getSnapshot() {
-    return this.PciProjectStorageSnapshotsService
-      .get(this.projectId, this.snapshotId)
-      .then((snapshot) => {
-        this.storage = new BlockStorage({
-          ...pick(
-            snapshot,
-            [
-              'region',
-              'name',
-              'size',
-              'bootable',
-            ],
-          ),
-          type: snapshot.volume.type,
-          snapshotId: snapshot.id,
-        });
-        return this.editStorage;
-      });
-  }
-
   save() {
-    this.loadings.save = true;
+    this.isLoading = true;
     return this.PciProjectStorageSnapshotsService
       .createVolume(this.projectId, this.storage)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_snapshots_snapshot_create-volume_success_message',
-            { volume: this.storage.name },
-          ),
-          'pci.projects.project.storages.snapshots.snapshot',
-        );
-
-        return this.goBack(true);
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_snapshots_snapshot_create-volume_success_message',
+        { volume: this.storage.name },
+      )))
       .catch((err) => {
         this.CucCloudMessage.error(
           this.$translate.instant(
@@ -107,7 +69,7 @@ export default class PciBlockStorageSnapshotsCreateVolumeController {
         );
       })
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.html
@@ -1,22 +1,14 @@
-<div class="p-5">
-    <div data-ng-if="$ctrl.loading" class="text-center">
-        <oui-spinner></oui-spinner>
-    </div>
-    <section data-ng-if="!$ctrl.loading">
-        <oui-back-button
-            data-on-click="$ctrl.goBack()">{{:: 'pci_projects_project_storages_snapshots_snapshot_create-volume_back_label' | translate }}</oui-back-button>
+<section>
+    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
 
-        <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
-
-        <pci-project-storage-volume-edit
-            data-ng-if="$ctrl.storage"
-            data-storage="$ctrl.storage"
-            data-project-id="$ctrl.projectId"
-            data-title="'pci_projects_project_storages_snapshots_snapshot_create-volume_title' | translate"
-            data-submit-label="'pci_projects_project_storages_snapshots_snapshot_create-volume_submit_label' | translate"
-            data-on-cancel="$ctrl.goBack()"
-            data-on-submit="$ctrl.save()"
-            data-show-loading="$ctrl.loadings.save">
-        </pci-project-storage-volume-edit>
-    </section>
-</div>
+    <pci-project-storage-volume-edit
+        data-ng-if="$ctrl.storage"
+        data-storage="$ctrl.storage"
+        data-project-id="$ctrl.projectId"
+        data-title="'pci_projects_project_storages_snapshots_snapshot_create-volume_title' | translate"
+        data-submit-label="'pci_projects_project_storages_snapshots_snapshot_create-volume_submit_label' | translate"
+        data-on-cancel="$ctrl.goBack()"
+        data-on-submit="$ctrl.save()"
+        data-show-loading="$ctrl.isLoading">
+    </pci-project-storage-volume-edit>
+</section>

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.module.js
@@ -1,0 +1,29 @@
+import angular from 'angular';
+import '@ovh-ux/ng-translate-async-loader';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-ui-angular';
+import 'ovh-api-services';
+
+import blockStorages from '../../../blocks';
+import volumeEdit from '../../../blocks/block/edit/volume-edit';
+import component from './create-volume.component';
+import routing from './create-volume.routing';
+
+const moduleName = 'ovhManagerPciStoragesSnapshotsCreateVolume';
+
+angular
+  .module(moduleName, [
+    'ui.router',
+    'oui',
+    'ovh-api-services',
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+    blockStorages,
+    volumeEdit,
+  ])
+  .config(routing)
+  .component('pciProjectStoragesSnapshotsCreateVolume', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/create-volume.routing.js
@@ -4,17 +4,28 @@ export default /* @ngInject */ ($stateProvider) => {
       url: '/new-volume',
       component: 'pciProjectStoragesSnapshotsCreateVolume',
       resolve: {
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_blocks_refresh');
-          }
-          return $state.go('pci.projects.project.storages.snapshots', {
+        goBack: /* @ngInject */ ($rootScope, CucCloudMessage, $state, projectId) => (message = false, type = 'success') => {
+          const reload = message && type === 'success';
+
+          const promise = $state.go(reload ? 'pci.projects.project.storages.blocks' : 'pci.projects.project.storages.snapshots', {
             projectId,
+          },
+          {
+            reload,
           });
+
+          if (message) {
+            promise.then(() => CucCloudMessage[type](message, reload ? 'pci.projects.project.storages.blocks' : 'pci.projects.project.storages.snapshots'));
+          }
+
+          return promise;
         },
         cancelLink: /* @ngInject */ ($state, projectId) => $state.href('pci.projects.project.storages.snapshots', {
           projectId,
         }),
+        breadcrumb: /* @ngInject */ $translate => $translate
+          .refresh()
+          .then(() => $translate.instant('pci_projects_project_storages_snapshots_snapshot_create-volume_title')),
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/index.js
@@ -1,25 +1,24 @@
 import angular from 'angular';
-import '@ovh-ux/ng-translate-async-loader';
 import '@uirouter/angularjs';
-import 'angular-translate';
-import 'ovh-ui-angular';
-import 'ovh-api-services';
+import 'oclazyload';
 
-import component from './create-volume.component';
-import routing from './create-volume.routing';
-
-const moduleName = 'ovhManagerPciStoragesSnapshotsCreateVolume';
+const moduleName = 'ovhManagerPciStoragesSnapshotsCreateVolumeLazyLoading';
 
 angular
   .module(moduleName, [
     'ui.router',
-    'oui',
-    'ovh-api-services',
-    'ngTranslateAsyncLoader',
-    'pascalprecht.translate',
+    'oc.lazyLoad',
   ])
-  .config(routing)
-  .component('pciProjectStoragesSnapshotsCreateVolume', component)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .config(/* @ngInject */($stateProvider) => {
+    $stateProvider.state('pci.projects.project.storages.snapshots.snapshot.create-volume.**', {
+      url: '/new-volume',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./create-volume.module')
+          .then(mod => $ocLazyLoad.inject(mod.default || mod));
+      },
+    });
+  });
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/create-volume/translations/Messages_fr_FR.json
@@ -1,11 +1,7 @@
 {
-  "pci_projects_project_storages_snapshots_snapshot_create-volume_back_label": "Retour",
   "pci_projects_project_storages_snapshots_snapshot_create-volume_title": "Créer un volume à partir du snapshot",
   "pci_projects_project_storages_snapshots_snapshot_create-volume_submit_label": "Créer le volume",
-
-
   "pci_projects_project_storages_snapshots_snapshot_create-volume_success_message": "Le volume {{ volume }} a été créé.",
-  "pci_projects_project_storages_snapshots_snapshot_create-volume_error_post": "Une erreur est survenue lors de la creation du volume {{ volume }} : {{ message }}",
-  "pci_projects_project_storages_snapshots_snapshot_create-volume_error_load": "Une erreur est survenue lors du chargement du snapshot : {{ message }}"
+  "pci_projects_project_storages_snapshots_snapshot_create-volume_error_post": "Une erreur est survenue lors de la creation du volume {{ volume }} : {{ message }}"
 
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     projectId: '<',
     snapshotId: '<',
+    snapshot: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.controller.js
@@ -1,90 +1,37 @@
 import get from 'lodash/get';
 
-export default class PciBlockStorageDetailsDeleteController {
+export default class PciSnapshotsSnapshotDeleteController {
   /* @ngInject */
   constructor(
     $translate,
-    CucCloudMessage,
     PciProjectStorageSnapshotsService,
   ) {
     this.$translate = $translate;
-    this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageSnapshotsService = PciProjectStorageSnapshotsService;
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
-
-    this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageSnapshotsService.get(this.projectId, this.snapshotId))
-      .then((snapshot) => {
-        this.snapshot = snapshot;
-        return this.snapshot;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_snapshots_snapshot_delete_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    this.CucCloudMessage.unSubscribe('pci.projects.project.storages.snapshots.delete');
-    this.messageHandler = this.CucCloudMessage.subscribe(
-      'pci.projects.project.storages.snapshots.delete',
-      {
-        onMessage: () => this.refreshMessages(),
-      },
-    );
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
+    this.isLoading = false;
   }
 
   deleteSnapshot() {
-    this.loadings.save = true;
+    this.isLoading = true;
     return this.PciProjectStorageSnapshotsService.delete(this.projectId, this.snapshot)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_snapshots_snapshot_delete_success_message',
-            {
-              snapshot: this.snapshot.name,
-            },
-          ),
-          'pci.projects.project.storages.snapshots',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_snapshots_snapshot_delete_error_delete',
-            {
-              message: get(err, 'data.message', null),
-              snapshot: this.snapshot.name,
-            },
-          ),
-        );
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_snapshots_snapshot_delete_success_message',
+        {
+          snapshot: this.snapshot.name,
+        },
+      )))
+      .catch(err => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_snapshots_snapshot_delete_error_delete',
+        {
+          message: get(err, 'data.message', null),
+          snapshot: this.snapshot.name,
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.html
@@ -2,13 +2,11 @@
     data-heading="{{ 'pci_projects_project_storages_snapshots_snapshot_delete_title' | translate }}"
     data-primary-action="$ctrl.deleteSnapshot()"
     data-primary-label="{{:: 'pci_projects_project_storages_snapshots_snapshot_delete_submit_label' | translate }}"
-    data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save"
+    data-primary-disabled="$ctrl.isLoading"
     data-secondary-action="$ctrl.goBack()"
     data-secondary-label="{{:: 'pci_projects_project_storages_snapshots_snapshot_delete_cancel_label' | translate }}"
     data-on-dismiss="$ctrl.goBack()"
-    data-loading="$ctrl.loadings.init || $ctrl.loadings.save">
-
-    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+    data-loading="$ctrl.isLoading">
 
     <p data-translate="pci_projects_project_storages_snapshots_snapshot_delete_content"
         data-translate-values="{ snapshot: $ctrl.snapshot.name }"></p>

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.module.js
@@ -1,0 +1,25 @@
+import angular from 'angular';
+import '@ovh-ux/ng-translate-async-loader';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-ui-angular';
+import 'ovh-api-services';
+
+import component from './delete.component';
+import routing from './delete.routing';
+
+const moduleName = 'ovhManagerPciStoragesSnapshotsSnapshotDelete';
+
+angular
+  .module(moduleName, [
+    'ui.router',
+    'oui',
+    'ovh-api-services',
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+  ])
+  .config(routing)
+  .component('pciProjectStoragesSnapshotsSnapshotDelete', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/delete.routing.js
@@ -10,14 +10,12 @@ export default /* @ngInject */($stateProvider) => {
       layout: 'modal',
       resolve: {
         snapshotId: /* @ngInject */$transition$ => $transition$.params().snapshotId,
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_blocks_refresh');
-          }
-          return $state.go('pci.projects.project.storages.snapshots', {
-            projectId,
-          });
-        },
+        snapshot: /* @ngInject */ (
+          PciProjectStorageSnapshotsService,
+          projectId,
+          snapshotId,
+        ) => PciProjectStorageSnapshotsService.get(projectId, snapshotId),
+        goBack: /* @ngInject */goToSnapshots => goToSnapshots,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/index.js
@@ -1,25 +1,24 @@
 import angular from 'angular';
-import '@ovh-ux/ng-translate-async-loader';
 import '@uirouter/angularjs';
-import 'angular-translate';
-import 'ovh-ui-angular';
-import 'ovh-api-services';
+import 'oclazyload';
 
-import component from './delete.component';
-import routing from './delete.routing';
-
-const moduleName = 'ovhManagerPciStoragesSnapshotsSnapshotDelete';
+const moduleName = 'ovhManagerPciStoragesSnapshotsSnapshotDeleteLazyLoading';
 
 angular
   .module(moduleName, [
     'ui.router',
-    'oui',
-    'ovh-api-services',
-    'ngTranslateAsyncLoader',
-    'pascalprecht.translate',
+    'oc.lazyLoad',
   ])
-  .config(routing)
-  .component('pciProjectStoragesSnapshotsSnapshotDelete', component)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .config(/* @ngInject */($stateProvider) => {
+    $stateProvider.state('pci.projects.project.storages.snapshots.delete.**', {
+      url: '/delete?snapshotId',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./delete.module')
+          .then(mod => $ocLazyLoad.inject(mod.default || mod));
+      },
+    });
+  });
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/delete/translations/Messages_fr_FR.json
@@ -4,7 +4,6 @@
   "pci_projects_project_storages_snapshots_snapshot_delete_cancel_label": "Annuler",
   "pci_projects_project_storages_snapshots_snapshot_delete_content": "Supprimer définitivement le snapshot {{ snapshot }}",
 
-  "pci_projects_project_storages_snapshots_snapshot_delete_error_load": "Une erreur est survenue lors du chargement du snapshot : {{ message }}",
   "pci_projects_project_storages_snapshots_snapshot_delete_success_message": "Le snapshot {{ snapshot }} est en cours de suppression",
   "pci_projects_project_storages_snapshots_snapshot_delete_error_delete": "Une erreur est survenue lors de la suppression du snapshot {{ snapshot }} : {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/index.js
@@ -1,32 +1,24 @@
 import angular from 'angular';
-import '@ovh-ux/manager-core';
-import '@ovh-ux/ng-translate-async-loader';
 import '@uirouter/angularjs';
-import 'angular-translate';
 import 'oclazyload';
-import 'ovh-ui-angular';
-import 'ovh-api-services';
 
-import snapshotCreateVolume from './create-volume';
-import snapshotDelete from './delete';
-
-import routing from './snapshot.routing';
-
-const moduleName = 'ovhManagerPciStoragesSnapshotsSnapshot';
+const moduleName = 'ovhManagerPciStoragesSnapshotsSnapshotLazyLoading';
 
 angular
   .module(moduleName, [
-    snapshotCreateVolume,
-    snapshotDelete,
     'ui.router',
     'oc.lazyLoad',
-    'oui',
-    'ovhManagerCore',
-    'ovh-api-services',
-    'ngTranslateAsyncLoader',
-    'pascalprecht.translate',
   ])
-  .config(routing)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .config(/* @ngInject */($stateProvider) => {
+    $stateProvider.state('pci.projects.project.storages.snapshots.snapshot.**', {
+      url: '/{snapshotId}',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./snapshot.module')
+          .then(mod => $ocLazyLoad.inject(mod.default || mod));
+      },
+    });
+  });
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/snapshot.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/snapshot.module.js
@@ -1,0 +1,31 @@
+import angular from 'angular';
+import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-translate-async-loader';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'oclazyload';
+import 'ovh-ui-angular';
+import 'ovh-api-services';
+
+import snapshotCreateVolume from './create-volume';
+
+
+import routing from './snapshot.routing';
+
+const moduleName = 'ovhManagerPciStoragesSnapshotsSnapshot';
+
+angular
+  .module(moduleName, [
+    snapshotCreateVolume,
+    'ui.router',
+    'oc.lazyLoad',
+    'oui',
+    'ovhManagerCore',
+    'ovh-api-services',
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+  ])
+  .config(routing)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/snapshot.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshot/snapshot.routing.js
@@ -5,6 +5,11 @@ export default /* @ngInject */($stateProvider) => {
       abstract: true,
       resolve: {
         snapshotId: /* @ngInject */$transition$ => $transition$.params().snapshotId,
+        snapshot: /* @ngInject */ (
+          PciProjectStorageSnapshotsService,
+          projectId,
+          snapshotId,
+        ) => PciProjectStorageSnapshotsService.get(projectId, snapshotId),
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.component.js
@@ -6,6 +6,7 @@ export default {
   template,
   bindings: {
     projectId: '<',
+    snapshots: '<',
     createVolume: '<',
     createSnapshot: '<',
     deleteSnapshot: '<',

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.controller.js
@@ -1,65 +1,22 @@
-import get from 'lodash/get';
-
 export default class PciStorageSnapshotsController {
   /* @ngInject */
   constructor(
-    $rootScope,
     $translate,
     CucCloudMessage,
+    CucRegionService,
     PciProjectStorageSnapshotsService,
   ) {
-    this.$rootScope = $rootScope;
     this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
+    this.CucRegionService = CucRegionService;
     this.PciProjectStorageSnapshotsService = PciProjectStorageSnapshotsService;
   }
 
   $onInit() {
-    this.$rootScope.$on('pci_storages_blocks_refresh', () => this.refreshBlocks());
-    this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loading = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.getSnapshots())
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          'pci_projects_project_storages_snapshots_error_query',
-          { message: get(err, 'data.message', '') },
-        ),
-      ))
-      .finally(() => {
-        this.loading = false;
-      });
-  }
-
-  getSnapshots() {
-    return this.PciProjectStorageSnapshotsService
-      .getAll(this.projectId)
-      .then((snapshots) => {
-        this.snapshots = snapshots;
-        return this.snapshots;
-      });
-  }
-
-  refreshBlocks() {
-    this.loading = true;
-    return this.getSnapshots()
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          'pci_projects_project_storages_snapshots_error_query',
-          { message: get(err, 'data.message', '') },
-        ),
-      ))
-      .finally(() => {
-        this.loading = false;
-      });
+    this.loadMessages();
   }
 
   loadMessages() {
-    this.CucCloudMessage.unSubscribe('pci.projects.project.storages.snapshots');
     this.messageHandler = this.CucCloudMessage.subscribe(
       'pci.projects.project.storages.snapshots',
       {

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.html
@@ -20,7 +20,9 @@
                 data-property="region"
                 data-type="string"
                 data-sortable
-                data-filterable></oui-column>
+                data-filterable>
+                <span data-ng-bind="$ctrl.CucRegionService.getTranslatedMicroRegion($row.region)"></span>
+            </oui-column>
             <oui-column
                 data-title="'pci_projects_project_storages_snapshots_volume_label' | translate"
                 data-property="volumeId"

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.module.js
@@ -1,0 +1,33 @@
+import angular from 'angular';
+import '@ovh-ux/ng-translate-async-loader';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-ui-angular';
+import 'ovh-api-services';
+
+import snapshot from './snapshot';
+import snapshotDelete from './snapshot/delete';
+
+import component from './snapshots.component';
+import service from './snapshots.service';
+
+import routing from './snapshots.routing';
+
+const moduleName = 'ovhManagerPciStoragesSnapshots';
+
+angular
+  .module(moduleName, [
+    'ngTranslateAsyncLoader',
+    'oui',
+    'ovh-api-services',
+    'pascalprecht.translate',
+    'ui.router',
+    snapshot,
+    snapshotDelete,
+  ])
+  .config(routing)
+  .component('pciProjectStoragesSnapshots', component)
+  .service('PciProjectStorageSnapshotsService', service)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/snapshots.routing.js
@@ -4,6 +4,10 @@ export default /* @ngInject */ ($stateProvider) => {
       url: '/volume-snapshots',
       component: 'pciProjectStoragesSnapshots',
       resolve: {
+        snapshots: /* @ngInject */ (
+          PciProjectStorageSnapshotsService,
+          projectId,
+        ) => PciProjectStorageSnapshotsService.getAll(projectId),
         createVolume: /* @ngInject */ ($state, projectId) => snapshot => $state
           .go('pci.projects.project.storages.snapshots.snapshot.create-volume', {
             projectId,
@@ -17,6 +21,25 @@ export default /* @ngInject */ ($stateProvider) => {
           projectId,
           snapshotId: snapshot.id,
         }),
+
+        goToSnapshots: /* @ngInject */ ($rootScope, CucCloudMessage, $state, projectId) => (message = false, type = 'success') => {
+          const reload = message && type === 'success';
+
+          const promise = $state.go('pci.projects.project.storages.snapshots', {
+            projectId,
+          },
+          {
+            reload,
+          });
+
+          if (message) {
+            promise.then(() => CucCloudMessage[type](message, 'pci.projects.project.storages.snapshots'));
+          }
+
+          return promise;
+        },
+
+
         breadcrumb: /* @ngInject */ $translate => $translate
           .refresh()
           .then(() => $translate.instant('pci_projects_project_storages_snapshots_title')),

--- a/packages/manager/modules/pci/src/projects/project/storages/snapshots/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/snapshots/translations/Messages_fr_FR.json
@@ -19,7 +19,5 @@
 
   "pci_projects_project_storages_snapshots_add_label": "Créer un snapshot de volume",
   "pci_projects_project_storages_snapshots_create_volume_label": "Créer un volume",
-  "pci_projects_project_storages_snapshots_delete_label": "Supprimer",
-
-  "pci_projects_project_storages_snapshots_error_query": "Une erreur est survenue lors de la récupération des snapshots"
+  "pci_projects_project_storages_snapshots_delete_label": "Supprimer"
 }


### PR DESCRIPTION
## fix: update volume snapshots list

### Description of the Change

- remove `CucCloudMessage` listener in modals
- add `goToSnapshots` resolve and use it in `goBack` sub resolve 
  - navigate to volume storages list and trigger a `CucCloudMessage`
  - if the message is a `success` message, `$state.go` is called with `reload: true` option
- move initial data loading in `resolve` and remove related code/translations
- Fix display of region (using `CucRegionService`)
- Fix missing dependencies (`PciProjectStorageBlockService` service and `ovhManagerPciStoragesBlocksBlockVolumeEdit`component are used in volume creation from snapshots)
- add lazy loading

e358dff6 — fix: update volume snapshots list

/cc @jleveugle @marie-j 
