### PR TITLE
fix: update instance backups

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/index.js
@@ -1,37 +1,24 @@
 import angular from 'angular';
-import '@ovh-ux/manager-core';
-import '@ovh-ux/ng-translate-async-loader';
 import '@uirouter/angularjs';
-import 'angular-translate';
-import 'ovh-ui-angular';
-import 'ovh-api-services';
-import 'angular-ui-bootstrap';
-import '@ovh-ux/ng-ovh-user-pref';
+import 'oclazyload';
 
-import component from './instance-backups.component';
-import service from './instance-backups.service';
-
-import instanceBackupDelete from './instance-backup/delete';
-
-import routing from './instance-backups.routing';
-
-const moduleName = 'ovhManagerPciStoragesInstanceBackups';
+const moduleName = 'ovhManagerPciStoragesInstanceBackupsLazyLoading';
 
 angular
   .module(moduleName, [
-    instanceBackupDelete,
-    'ngOvhUserPref',
-    'ngTranslateAsyncLoader',
-    'oui',
-    'ovh-api-services',
-    'ovhManagerCore',
-    'pascalprecht.translate',
     'ui.router',
-    'ui.bootstrap',
+    'oc.lazyLoad',
   ])
-  .config(routing)
-  .component('pciProjectStorageInstanceBackups', component)
-  .service('PciProjectStorageInstanceBackupService', service)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .config(/* @ngInject */($stateProvider) => {
+    $stateProvider.state('pci.projects.project.storages.instance-backups.**', {
+      url: '/instance-backups',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./instance-backups.module')
+          .then(mod => $ocLazyLoad.inject(mod.default || mod));
+      },
+    });
+  });
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup.class.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup.class.js
@@ -9,8 +9,8 @@ export default class InstanceBackup {
     if (includes(['active'], this.status)) {
       return 'ACTIVE';
     }
-    if (includes(['saving'], this.status)) {
-      return 'SAVING';
+    if (includes(['saving', 'deleting', 'queued'], this.status)) {
+      return 'PENDING';
     }
     return this.status.toUpperCase();
   }

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     projectId: '<',
     instanceBackupId: '<',
+    instanceBackup: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.controller.js
@@ -4,91 +4,37 @@ export default class PciBlockStorageDetailsDeleteController {
   /* @ngInject */
   constructor(
     $translate,
-    CucCloudMessage,
     PciProjectStorageInstanceBackupService,
   ) {
     this.$translate = $translate;
-    this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageInstanceBackupService = PciProjectStorageInstanceBackupService;
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
-
-    this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageInstanceBackupService
-        .get(this.projectId, this.instanceBackupId))
-      .then((instanceBackup) => {
-        this.instanceBackup = instanceBackup;
-        return this.instanceBackup;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_volume-instances_volume-instance_delete_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    return new Promise((resolve) => {
-      this.CucCloudMessage.unSubscribe('pci.projects.project.storages.volume-instances.delete');
-      this.messageHandler = this.CucCloudMessage.subscribe(
-        'pci.projects.project.storages.volume-instances.delete',
-        {
-          onMessage: () => this.refreshMessages(),
-        },
-      );
-      resolve();
-    });
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
+    this.isLoading = false;
   }
 
   deleteStorage() {
-    this.loadings.save = true;
-    return this.PciProjectStorageInstanceBackupService.delete(this.projectId, this.instanceBackup)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_volume-instances_volume-instance_delete_success_message',
-            {
-              snapshot: this.instanceBackup.name,
-            },
-          ),
-          'pci.projects.project.storages.instance-backups',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_volume-instances_volume-instance_delete_error_delete',
-            {
-              message: get(err, 'data.message', null),
-              snapshot: this.instanceBackup.name,
-            },
-          ),
-        );
-      })
+    this.isLoading = true;
+    return this.PciProjectStorageInstanceBackupService
+      .delete(this.projectId, this.instanceBackup)
+      .then(() => this.goBack(
+        this.$translate.instant(
+          'pci_projects_project_storages_volume-instances_volume-instance_delete_success_message',
+          {
+            backup: this.instanceBackup.name,
+          },
+        ),
+      ))
+      .catch(err => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_volume-instances_volume-instance_delete_error_delete',
+        {
+          message: get(err, 'data.message', null),
+          backup: this.instanceBackup.name,
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.html
@@ -2,17 +2,15 @@
     data-heading="{{ 'pci_projects_project_storages_volume-instances_volume-instance_delete_title' | translate }}"
     data-primary-action="$ctrl.deleteStorage()"
     data-primary-label="{{:: 'pci_projects_project_storages_volume-instances_volume-instance_delete_submit_label' | translate }}"
-    data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save || !$ctrl.instanceBackup.isDeletable()"
+    data-primary-disabled="$ctrl.isLoading || !$ctrl.instanceBackup.isDeletable()"
     data-secondary-action="$ctrl.goBack()"
     data-secondary-label="{{:: 'pci_projects_project_storages_volume-instances_volume-instance_delete_cancel_label' | translate }}"
     data-on-dismiss="$ctrl.goBack()"
-    data-loading="$ctrl.loadings.init">
-
-    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+    data-loading="$ctrl.isLoading">
 
     <div data-ng-if="$ctrl.instanceBackup.isDeletable()">
         <p data-translate="pci_projects_project_storages_volume-instances_volume-instance_delete_content"
-            data-translate-values="{ snapshot: $ctrl.instanceBackup.name }"></p>
+            data-translate-values="{ backup: $ctrl.instanceBackup.name }"></p>
         <oui-message data-type="warning">
             <span data-translate="pci_projects_project_storages_volume-instances_volume-instance_delete_erase_message"></span>
         </oui-message>
@@ -22,9 +20,4 @@
             <span data-translate="pci_projects_project_storages_volume-instances_volume-instance_delete_error_not_deletable"></span>
         </oui-message>
     </div>
-
-    <div data-ng-if="$ctrl.loadings.save" class="text-center">
-        <oui-spinner></oui-spinner>
-    </div>
-
 </oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.module.js
@@ -1,0 +1,24 @@
+import angular from 'angular';
+import '@ovh-ux/ng-translate-async-loader';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-ui-angular';
+import 'ovh-api-services';
+
+import component from './delete.component';
+import routing from './delete.routing';
+
+const moduleName = 'pciProjectStorageInstanceBackupsDelete';
+
+angular
+  .module(moduleName, [
+    'ui.router',
+    'oui',
+    'ovh-api-services',
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+  ])
+  .config(routing)
+  .component('pciProjectStorageInstanceBackupsDelete', component);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/delete.routing.js
@@ -8,16 +8,20 @@ export default /* @ngInject */($stateProvider) => {
         },
       },
       layout: 'modal',
+      translations: {
+        value: ['.'],
+        format: 'json',
+      },
       resolve: {
         instanceBackupId: /* @ngInject */$transition$ => $transition$.params().instanceBackupId,
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_instance-backups_refresh');
-          }
-          return $state.go('pci.projects.project.storages.instance-backups', {
-            projectId,
-          });
-        },
+        instanceBackup: /* @ngInject */ (
+          PciProjectStorageInstanceBackupService,
+          projectId,
+          instanceBackupId,
+        ) => PciProjectStorageInstanceBackupService
+          .get(projectId, instanceBackupId),
+
+        goBack: /* @ngInject */ goToInstanceBackups => goToInstanceBackups,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/index.js
@@ -1,25 +1,24 @@
 import angular from 'angular';
-import '@ovh-ux/ng-translate-async-loader';
 import '@uirouter/angularjs';
-import 'angular-translate';
-import 'ovh-ui-angular';
-import 'ovh-api-services';
+import 'oclazyload';
 
-import component from './delete.component';
-import routing from './delete.routing';
-
-const moduleName = 'pciProjectStorageInstanceBackupsDelete';
+const moduleName = 'pciProjectStorageInstanceBackupsDeleteLazyLoading';
 
 angular
   .module(moduleName, [
     'ui.router',
-    'oui',
-    'ovh-api-services',
-    'ngTranslateAsyncLoader',
-    'pascalprecht.translate',
+    'oc.lazyLoad',
   ])
-  .config(routing)
-  .component('pciProjectStorageInstanceBackupsDelete', component)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .config(/* @ngInject */($stateProvider) => {
+    $stateProvider.state('pci.projects.project.storages.instance-backups.delete.**', {
+      url: '/delete?instanceBackupId',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./delete.module')
+          .then(mod => $ocLazyLoad.inject(mod.default || mod));
+      },
+    });
+  });
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backup/delete/translations/Messages_fr_FR.json
@@ -2,11 +2,11 @@
   "pci_projects_project_storages_volume-instances_volume-instance_delete_title": "Supprimer un backup",
   "pci_projects_project_storages_volume-instances_volume-instance_delete_submit_label": "Confirmer",
   "pci_projects_project_storages_volume-instances_volume-instance_delete_cancel_label": "Annuler",
-  "pci_projects_project_storages_volume-instances_volume-instance_delete_content": "Supprimer définitivement {{ snapshot }}",
+  "pci_projects_project_storages_volume-instances_volume-instance_delete_content": "Supprimer définitivement {{ backup }}",
   "pci_projects_project_storages_volume-instances_volume-instance_delete_erase_message": "Toutes les données sur le backup d'instance seront perdues.",
   "pci_projects_project_storages_volume-instances_volume-instance_delete_error_not_deletable": "Il n'est pas possible de supprimer ce backup d'instance actuellement.",
 
   "pci_projects_project_storages_volume-instances_volume-instance_delete_error_load": "Une erreur est survenue lors du chargement du backup d'instance : {{ message }}.",
-  "pci_projects_project_storages_volume-instances_volume-instance_delete_success_message": "Le backup d'instance {{ snapshot }} a été supprimé.",
-  "pci_projects_project_storages_volume-instances_volume-instance_delete_error_delete": "Une erreur est survenue lors de la suppression du backup d'instance {{ snapshot }} : {{ message }}."
+  "pci_projects_project_storages_volume-instances_volume-instance_delete_success_message": "Le backup d'instance {{ backup }} a été supprimé.",
+  "pci_projects_project_storages_volume-instances_volume-instance_delete_error_delete": "Une erreur est survenue lors de la suppression du backup d'instance {{ backup }} : {{ message }}."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     projectId: '<',
     addInstanceBackup: '<',
+    instanceBackups: '<',
     createInstance: '<',
     deleteInstanceBackup: '<',
   },

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.controller.js
@@ -1,67 +1,18 @@
-import get from 'lodash/get';
-
 export default class PciInstanceBackupsController {
   /* @ngInject */
   constructor(
-    $rootScope,
-    $translate,
     CucCloudMessage,
     CucRegionService,
-    PciProjectStorageInstanceBackupService,
   ) {
-    this.$rootScope = $rootScope;
-    this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
     this.CucRegionService = CucRegionService;
-    this.PciProjectStorageInstanceBackupService = PciProjectStorageInstanceBackupService;
   }
 
   $onInit() {
-    this.$rootScope.$on('pci_instance_backups_refresh', () => this.refreshInstanceBackups());
-    this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loading = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.getInstanceBackups())
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          'pci_projects_project_storages_instance_backups_error_query',
-          { message: get(err, 'data.message', '') },
-        ),
-      ))
-      .finally(() => {
-        this.loading = false;
-      });
-  }
-
-  getInstanceBackups() {
-    return this.PciProjectStorageInstanceBackupService
-      .getAll(this.projectId)
-      .then((instanceBackups) => {
-        this.instanceBackups = instanceBackups;
-        return this.instanceBackups;
-      });
-  }
-
-  refreshInstanceBackups() {
-    this.loading = true;
-    return this.getInstanceBackups()
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          'pci_projects_project_storages_instance_backups_error_query',
-          { message: get(err, 'data.message', '') },
-        ),
-      ))
-      .finally(() => {
-        this.loading = false;
-      });
+    this.loadMessages();
   }
 
   loadMessages() {
-    this.CucCloudMessage.unSubscribe('pci.projects.project.storages.instance-backups');
     this.messageHandler = this.CucCloudMessage.subscribe(
       'pci.projects.project.storages.instance-backups',
       {

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.html
@@ -1,77 +1,77 @@
 <section
     data-ui-view>
-    <div class="p-5">
-        <h1 data-translate="pci_projects_project_storages_instance-backups_title"></h1>
+    <h1 data-translate="pci_projects_project_storages_instance-backups_title"></h1>
 
-        <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
 
-        <oui-datagrid
-            data-rows="$ctrl.instanceBackups"
-            data-page-size="5">
-            <oui-column
-                data-title="'pci_projects_project_storages_instance-backups_name_label' | translate"
-                data-property="name"
-                data-type="string"
-                data-searchable
-                data-sortable="asc"
-                data-filterable></oui-column>
-            <oui-column
-                data-title="'pci_projects_project_storages_instance-backups_region_label' | translate"
-                data-property="region"
-                data-type="string"
-                data-sortable
-                data-filterable>
-                <span data-ng-bind="$ctrl.CucRegionService.getTranslatedMicroRegion($row.region)"></span>
-            </oui-column>
-            <oui-column
-                data-title="'pci_projects_project_storages_instance-backups_size_label' | translate"
-                data-property="size"
-                data-type="number"
-                data-sortable
-                data-filterable>
-                <span>{{ $value | cucBytes:2:true:'GiB'}}</span>
-            </oui-column>
-            <oui-column
-                data-title=":: 'pci_projects_project_storages_containers_container_creationDate_label' | translate"
-                data-property="creationDate"
-                data-type="date"
-                data-sortable
-                data-filterable>
-                <span data-ng-bind="$value | date:'medium'"></span>
-            </oui-column>
-            <oui-column
-                data-title="'pci_projects_project_storages_instance-backups_status_label' | translate"
-                data-property="status"
-                data-sortable
-                data-filterable>
-                <span class="oui-status"
-                    data-ng-class="{
-                        'oui-status_success': ($row.statusGroup === 'ACTIVE'),
-                        'oui-status_warning': ($row.statusGroup === 'SAVING'),
-                        'oui-status_error': ($row.statusGroup === 'ERROR'),
-                        'oui-status_info': ($row.statusGroup === $row.status),
-                    }"
-                    data-ng-switch="$row.statusGroup">
-                    <span data-ng-bind="'pci_projects_project_storages_instance-backups_status_' + $row.statusGroup | translate"></span>
-                </span>
-            </oui-column>
+    <oui-datagrid
+        data-rows="$ctrl.instanceBackups"
+        data-page-size="5">
+        <oui-column
+            data-title="'pci_projects_project_storages_instance-backups_name_label' | translate"
+            data-property="name"
+            data-type="string"
+            data-searchable
+            data-sortable="asc"
+            data-filterable></oui-column>
+        <oui-column
+            data-title="'pci_projects_project_storages_instance-backups_region_label' | translate"
+            data-property="region"
+            data-type="string"
+            data-sortable
+            data-filterable>
+            <span data-ng-bind="$ctrl.CucRegionService.getTranslatedMicroRegion($row.region)"></span>
+        </oui-column>
+        <oui-column
+            data-title="'pci_projects_project_storages_instance-backups_size_label' | translate"
+            data-property="size"
+            data-type="number"
+            data-sortable
+            data-filterable>
+            <span>{{ $value | cucBytes:2:true:'GiB'}}</span>
+        </oui-column>
+        <oui-column
+            data-title=":: 'pci_projects_project_storages_containers_container_creationDate_label' | translate"
+            data-property="creationDate"
+            data-type="date"
+            data-sortable
+            data-filterable>
+            <span data-ng-bind="$value | date:'medium'"></span>
+        </oui-column>
+        <oui-column
+            data-title="'pci_projects_project_storages_instance-backups_status_label' | translate"
+            data-property="status"
+            data-sortable
+            data-filterable>
+            <span class="oui-status"
+                data-ng-class="{
+                    'oui-status_success': ($row.statusGroup === 'ACTIVE'),
+                    'oui-status_warning': ($row.statusGroup === 'PENDING'),
+                    'oui-status_error': ($row.statusGroup === 'ERROR'),
+                    'oui-status_info': ($row.statusGroup === $row.status),
+                }"
+                data-ng-switch="$row.statusGroup">
+                <span data-ng-bind="'pci_projects_project_storages_instance-backups_status_' + $row.status | translate"></span>
+            </span>
+        </oui-column>
 
-            <oui-action-menu data-align="end" data-compact>
-                <oui-action-menu-item data-on-click="$ctrl.createInstance($row)">
-                    <span data-translate="pci_projects_project_storages_instance-backups_instance_create_label"></span>
-                </oui-action-menu-item>
-                <oui-action-menu-item data-on-click="$ctrl.deleteInstanceBackup($row)">
-                    <span data-translate="pci_projects_project_storages_instance-backups_delete_label"></span>
-                </oui-action-menu-item>
-            </oui-action-menu>
+        <oui-action-menu data-align="end" data-compact>
+            <oui-action-menu-item data-on-click="$ctrl.createInstance($row)"
+                data-disabled>
+                <span data-translate="pci_projects_project_storages_instance-backups_instance_create_label"></span>
+            </oui-action-menu-item>
+            <oui-action-menu-item data-on-click="$ctrl.deleteInstanceBackup($row)"
+                data-ng-if="$row.statusGroup === 'ACTIVE'">
+                <span data-translate="pci_projects_project_storages_instance-backups_delete_label"></span>
+            </oui-action-menu-item>
+        </oui-action-menu>
 
-            <extra-top>
-                <oui-button
-                    data-on-click="$ctrl.addInstanceBackup()" >
-                    <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i>
-                    <span data-translate="pci_projects_project_storages_instance-backups_add_label"></span>
-                </oui-button>
-            </extra-top>
-        </oui-datagrid>
-    </div>
+        <extra-top>
+            <oui-button
+                data-on-click="$ctrl.addInstanceBackup()" >
+                <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i>
+                <span data-translate="pci_projects_project_storages_instance-backups_add_label"></span>
+            </oui-button>
+        </extra-top>
+    </oui-datagrid>
 </section>

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.module.js
@@ -1,0 +1,36 @@
+import angular from 'angular';
+import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-translate-async-loader';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-ui-angular';
+import 'ovh-api-services';
+import 'angular-ui-bootstrap';
+import '@ovh-ux/ng-ovh-user-pref';
+
+import component from './instance-backups.component';
+import service from './instance-backups.service';
+
+import instanceBackupDelete from './instance-backup/delete';
+
+import routing from './instance-backups.routing';
+
+const moduleName = 'ovhManagerPciStoragesInstanceBackups';
+
+angular
+  .module(moduleName, [
+    instanceBackupDelete,
+    'ngOvhUserPref',
+    'ngTranslateAsyncLoader',
+    'oui',
+    'ovh-api-services',
+    'ovhManagerCore',
+    'pascalprecht.translate',
+    'ui.router',
+    'ui.bootstrap',
+  ])
+  .config(routing)
+  .component('pciProjectStorageInstanceBackups', component)
+  .service('PciProjectStorageInstanceBackupService', service);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/instance-backups.routing.js
@@ -3,7 +3,37 @@ export default /* @ngInject */ ($stateProvider) => {
     .state('pci.projects.project.storages.instance-backups', {
       url: '/instance-backups',
       component: 'pciProjectStorageInstanceBackups',
+      translations: {
+        value: ['.'],
+        format: 'json',
+      },
       resolve: {
+        instanceBackups: /* @ngInject */ (
+          PciProjectStorageInstanceBackupService,
+          projectId,
+        ) => PciProjectStorageInstanceBackupService
+          .getAll(projectId),
+
+        goToInstanceBackups: /* @ngInject */ ($rootScope, CucCloudMessage, $state, projectId) => (message = false, type = 'success') => {
+          const reload = message && type === 'success';
+
+          const promise = $state.go('pci.projects.project.storages.instance-backups', {
+            projectId,
+          },
+          {
+            reload,
+          });
+
+          if (message) {
+            promise.then(() => CucCloudMessage[type](message, 'pci.projects.project.storages.instance-backups'));
+          }
+
+          return promise;
+        },
+        breadcrumb: /* @ngInject */ $translate => $translate
+          .refresh()
+          .then(() => $translate.instant('pci_projects_project_storages_instance-backups_title')),
+
         addInstanceBackup: /* @ngInject */($state, projectId) => () => $state.go('pci.projects.project.instances', {
           projectId,
         }),

--- a/packages/manager/modules/pci/src/projects/project/storages/instance-backups/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/instance-backups/translations/Messages_fr_FR.json
@@ -5,9 +5,10 @@
   "pci_projects_project_storages_instance-backups_size_label": "Taille",
   "pci_projects_project_storages_containers_container_creationDate_label": "Date de création",
   "pci_projects_project_storages_instance-backups_status_label": "Statut",
-  "pci_projects_project_storages_instance-backups_status_ACTIVE": "Activé",
-  "pci_projects_project_storages_instance-backups_status_SAVING": "Backup en cours",
-  "pci_projects_project_storages_instance-backups_status_QUEUED": "Backup en cours",
+  "pci_projects_project_storages_instance-backups_status_active": "Activé",
+  "pci_projects_project_storages_instance-backups_status_saving": "Backup en cours",
+  "pci_projects_project_storages_instance-backups_status_queued": "Backup en cours",
+  "pci_projects_project_storages_instance-backups_status_deleting": "Suppression en cours",
   "pci_projects_project_storages_instance-backups_instance_create_label": "Créer une instance",
   "pci_projects_project_storages_instance-backups_delete_label": "Supprimer",
   "pci_projects_project_storages_instance-backups_add_label": "Créer un backup d'instance"


### PR DESCRIPTION
## fix: update instance backups

### Description of the Change

- remove `CucCloudMessage` listener in modals
- add `goToInstanceBackups` resolve and use it in `goBack` sub resolve 
  - navigate to instance backup list and trigger a `CucCloudMessage`
  - if the message is a `success` message, `$state.go`is called with `reload: true` option
- move initial data loading in `resolve` and remove related code/translations
- Fix translations (wording)
- add missing lazy loading


e7f538f8 — fix: update instance backups
