### PR TITLE
fix: update containers storages

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/add/add.routing.js
@@ -4,17 +4,18 @@ export default /* @ngInject */ ($stateProvider) => {
       url: '/new',
       component: 'pciProjectStorageContainersAdd',
       resolve: {
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_containers_refresh');
-          }
-          return $state.go('pci.projects.project.storages.archives', {
-            projectId,
-          });
-        },
+        regions: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+        ) => PciProjectStorageBlockService.getAvailablesRegions(projectId),
+        goBack: /* @ngInject */ goToStorageContainers => goToStorageContainers,
         cancelLink: /* @ngInject */ ($state, projectId) => $state.href('pci.projects.project.storages.archives', {
           projectId,
         }),
+
+        breadcrumb: /* @ngInject */ $translate => $translate
+          .refresh()
+          .then(() => $translate.instant('pci_projects_project_storages_containers_add_title')),
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archive/cloud-archive.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archive/cloud-archive.routing.js
@@ -5,6 +5,18 @@ export default /* @ngInject */ ($stateProvider) => {
       component: 'pciProjectStorageContainersContainer',
       resolve: {
         containerId: /* @ngInject */ $transition$ => $transition$.params().containerId,
+        container: /* @ngInject */ (
+          PciProjectStorageContainersService,
+          projectId,
+          containerId,
+        ) => PciProjectStorageContainersService.getContainer(projectId, containerId),
+
+        defaultPassword: /* @ngInject */ (
+          PciProjectStorageContainersService,
+          projectId,
+          container,
+        ) => PciProjectStorageContainersService.getArchivePassword(projectId, container),
+
         addObject: /* @ngInject */ ($state, projectId, containerId) => () => $state.go('pci.projects.project.storages.archives.archive.add', {
           projectId,
           containerId,
@@ -14,6 +26,30 @@ export default /* @ngInject */ ($stateProvider) => {
           containerId,
           objectId: object.name,
         }),
+
+        goBack: /* @ngInject */ goToStorageContainers => goToStorageContainers,
+
+        goToStorageContainer: /* @ngInject */ ($rootScope, CucCloudMessage, $state, projectId, containerId) => (message = false, type = 'success') => {
+          const reload = message && type === 'success';
+
+          const promise = $state.go('pci.projects.project.storages.archives.archive', {
+            projectId,
+            containerId,
+          },
+          {
+            reload,
+          });
+
+          if (message) {
+            promise.then(() => CucCloudMessage[type](message, 'pci.projects.project.storages.containers.container'));
+          }
+
+          return promise;
+        },
+
+        refresh: /* @ngInject */ goToStorageContainer => goToStorageContainer,
+
+        breadcrumb: /* @ngInject */ container => container.name,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archive/delete/delete.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archive/delete/delete.routing.js
@@ -10,14 +10,12 @@ export default /* @ngInject */ ($stateProvider) => {
       layout: 'modal',
       resolve: {
         containerId: /* @ngInject */$transition$ => $transition$.params().containerId,
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_containers_refresh');
-          }
-          return $state.go('pci.projects.project.storages.archives', {
-            projectId,
-          });
-        },
+        container: /* @ngInject */ (
+          PciProjectStorageContainersService,
+          projectId,
+          containerId,
+        ) => PciProjectStorageContainersService.getContainer(projectId, containerId),
+        goBack: /* @ngInject */ goToStorageContainers => goToStorageContainers,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archive/object/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archive/object/add/add.routing.js
@@ -10,20 +10,7 @@ export default /* @ngInject */ ($stateProvider) => {
       layout: 'modal',
       resolve: {
         archive: () => true,
-        goBack: /* @ngInject */ (
-          $rootScope,
-          $state,
-          projectId,
-          containerId,
-        ) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_containers_container_refresh');
-          }
-          return $state.go('pci.projects.project.storages.archives.archive', {
-            projectId,
-            containerId,
-          });
-        },
+        goBack: /* @ngInject */ goToStorageContainer => goToStorageContainer,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archive/object/delete/delete.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archive/object/delete/delete.routing.js
@@ -10,20 +10,12 @@ export default /* @ngInject */ ($stateProvider) => {
       layout: 'modal',
       resolve: {
         objectId: /* @ngInject */$transition$ => $transition$.params().objectId,
-        goBack: /* @ngInject */ (
-          $rootScope,
-          $state,
-          projectId,
-          containerId,
-        ) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_containers_container_refresh');
-          }
-          return $state.go('pci.projects.project.storages.archives.archive', {
-            projectId,
-            containerId,
-          });
-        },
+        object: /* @ngInject */ (
+          container,
+          objectId,
+        ) => container.getObjectById(objectId),
+
+        goBack: /* @ngInject */ goToStorageContainer => goToStorageContainer,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archives.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/cloud-archives.routing.js
@@ -5,6 +5,11 @@ export default /* @ngInject */ ($stateProvider) => {
       component: 'pciProjectStorageContainers',
       resolve: {
         archive: () => true,
+        containers: /* @ngInject */ (
+          PciProjectStorageContainersService,
+          archive,
+          projectId,
+        ) => PciProjectStorageContainersService.getAll(projectId, archive),
         addContainer: /* @ngInject */($state, projectId) => () => $state.go('pci.projects.project.storages.archives.add', {
           projectId,
         }),
@@ -16,6 +21,28 @@ export default /* @ngInject */ ($stateProvider) => {
           projectId,
           containerId: container.id,
         }),
+        containerLink: /* @ngInject */($state, projectId) => container => $state.href('pci.projects.project.storages.archives.archive', {
+          projectId,
+          containerId: container.id,
+        }),
+
+        goToStorageContainers: /* @ngInject */ ($rootScope, CucCloudMessage, $state, projectId) => (message = false, type = 'success') => {
+          const reload = message && type === 'success';
+
+          const promise = $state.go('pci.projects.project.storages.archives', {
+            projectId,
+          },
+          {
+            reload,
+          });
+
+          if (message) {
+            promise.then(() => CucCloudMessage[type](message, 'pci.projects.project.storages.containers'));
+          }
+
+          return promise;
+        },
+
         breadcrumb: /* @ngInject */ $translate => $translate
           .refresh()
           .then(() => $translate.instant('pci_projects_project_storages_containers_archive_title')),

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     projectId: '<',
     archive: '<',
+    regions: '<',
     goBack: '<',
     cancelLink: '<',
   },

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.controller.js
@@ -22,6 +22,10 @@ export default class PciStoragesContainersAddController {
   }
 
   $onInit() {
+    this.loadMessages();
+
+    this.isLoading = false;
+
     this.displaySelectedRegion = false;
     this.displaySelectedType = false;
 
@@ -34,38 +38,12 @@ export default class PciStoragesContainersAddController {
       }),
     );
 
-    this.loadings = {
-      regions: true,
-      types: false,
-      save: false,
-    };
-
     this.container = new Container({
       archive: this.archive,
     });
-
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageBlockService.getAvailablesRegions(this.projectId))
-      .then((regions) => {
-        this.regions = regions;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_containers_add_error_query',
-            { message: get(err, 'data.message', '') },
-          ),
-          'pci.projects.project.storages.containers.add',
-        );
-      })
-      .finally(() => {
-        this.loadings.regions = false;
-      });
   }
 
   loadMessages() {
-    this.CucCloudMessage.unSubscribe('pci.projects.project.storages.containers.add');
     this.messageHandler = this.CucCloudMessage.subscribe(
       'pci.projects.project.storages.containers.add',
       {
@@ -96,21 +74,15 @@ export default class PciStoragesContainersAddController {
   }
 
   add() {
-    this.loadings.save = true;
-
+    this.isLoading = true;
     return this.PciProjectStorageContainersService
       .addContainer(this.projectId, this.container)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_containers_add_success_message',
-            { container: this.container.name },
-          ),
-          'pci.projects.project.storages.containers',
-        );
-
-        return this.goBack(true);
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_containers_add_success_message',
+        {
+          container: this.container.name,
+        },
+      )))
       .catch((err) => {
         this.CucCloudMessage.error(
           this.$translate.instant(
@@ -121,7 +93,7 @@ export default class PciStoragesContainersAddController {
         );
       })
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
@@ -1,68 +1,62 @@
-<div class="p-5">
-    <oui-back-button
-        data-on-click="$ctrl.goBack()">{{:: 'pci_projects_project_storages_containers_add_back_label' | translate }}</oui-back-button>
+<h1 data-translate="pci_projects_project_storages_containers_add_title"></h1>
 
-    <h1 data-translate="pci_projects_project_storages_containers_add_title"></h1>
+<cui-message-container data-messages="$ctrl.messages"></cui-message-container>
 
-    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+<oui-stepper
+    data-on-finish="$ctrl.add()">
+    <oui-step-form
+        data-header="{{:: 'pci_projects_project_storages_containers_add_region_title' | translate }}"
+        data-navigation="$ctrl.container.region"
+        data-on-focus="$ctrl.onRegionsFocus()"
+        data-on-submit="$ctrl.onRegionChange()"
+        data-editable="!$ctrl.isLoading">
+        <pci-project-regions-list
+            data-regions="$ctrl.regions"
+            data-selected-region="$ctrl.container.region"
+            data-display-selected-region="$ctrl.displaySelectedRegion"></pci-project-regions-list>
+    </oui-step-form>
 
-    <oui-stepper
-        data-on-finish="$ctrl.add()">
-        <oui-step-form
-            data-header="{{:: 'pci_projects_project_storages_containers_add_region_title' | translate }}"
-            data-loading="$ctrl.loadings.regions"
-            data-navigation="$ctrl.container.region"
-            data-on-focus="$ctrl.onRegionsFocus()"
-            data-on-submit="$ctrl.onRegionChange()"
-            data-editable="!$ctrl.loadings.save">
-            <pci-project-regions-list
-                data-regions="$ctrl.regions"
-                data-selected-region="$ctrl.container.region"
-                data-display-selected-region="$ctrl.displaySelectedRegion"></pci-project-regions-list>
-        </oui-step-form>
-
-        <oui-step-form
-            data-header="{{:: 'pci_projects_project_storages_containers_add_type_title' | translate }}"
-            data-ng-if="!$ctrl.archive"
-            data-position="2"
-            data-on-focus="$ctrl.onTypesFocus()"
-            data-on-submit="$ctrl.onTypeChange()"
-            data-navigation="$ctrl.selectedType"
-            data-editable="!$ctrl.loadings.save">
-            <div class="container-fluid px-0">
-                <div class="row">
-                    <oui-select-picker
-                        data-ng-if="!$ctrl.displaySelectedType || $ctrl.selectedType === type"
-                        data-ng-repeat="type in $ctrl.typesList track by $index"
-                        class="d-inline-block col-md-6 col-lg-4 my-3"
-                        data-name="type"
-                        data-match="name"
-                        data-model="$ctrl.selectedType"
-                        data-label="{{ 'pci_projects_project_storages_containers_add_type_' + type.id + '_label' | translate }}"
-                        data-values="[type]"
-                        data-variant="light"
-                        data-required>
-                    </oui-select-picker>
-                </div>
+    <oui-step-form
+        data-header="{{:: 'pci_projects_project_storages_containers_add_type_title' | translate }}"
+        data-ng-if="!$ctrl.archive"
+        data-position="2"
+        data-on-focus="$ctrl.onTypesFocus()"
+        data-on-submit="$ctrl.onTypeChange()"
+        data-navigation="$ctrl.selectedType"
+        data-editable="!$ctrl.isLoading">
+        <div class="container-fluid px-0">
+            <div class="row">
+                <oui-select-picker
+                    data-ng-if="!$ctrl.displaySelectedType || $ctrl.selectedType === type"
+                    data-ng-repeat="type in $ctrl.typesList track by $index"
+                    class="d-inline-block col-md-6 col-lg-4 my-3"
+                    data-name="type"
+                    data-match="name"
+                    data-model="$ctrl.selectedType"
+                    data-label="{{ 'pci_projects_project_storages_containers_add_type_' + type.id + '_label' | translate }}"
+                    data-values="[type]"
+                    data-variant="light"
+                    data-required>
+                </oui-select-picker>
             </div>
-        </oui-step-form>
+        </div>
+    </oui-step-form>
 
-        <oui-step-form data-header="{{:: 'pci_projects_project_storages_containers_add_name_title' | translate }}"
-            data-editable="!$ctrl.loadings.save"
-            data-cancel-href="{{$ctrl.cancelLink}}"
-            data-cancel-text="{{:: 'pci_projects_project_storages_containers_add_cancel_label' | translate }}"
-            data-submit-text="{{:: 'pci_projects_project_storages_containers_add_submit_label' | translate }}">
-            <oui-field data-size="xl">
-                <input class="oui-input" type="text" name="name"
-                    data-ng-model="$ctrl.container.name"
-                    data-ng-required="true">
-            </oui-field>
-        </oui-step-form>
+    <oui-step-form data-header="{{:: 'pci_projects_project_storages_containers_add_name_title' | translate }}"
+        data-editable="!$ctrl.isLoading"
+        data-cancel-href="{{$ctrl.cancelLink}}"
+        data-cancel-text="{{:: 'pci_projects_project_storages_containers_add_cancel_label' | translate }}"
+        data-submit-text="{{:: 'pci_projects_project_storages_containers_add_submit_label' | translate }}">
+        <oui-field data-size="xl">
+            <input class="oui-input" type="text" name="name"
+                data-ng-model="$ctrl.container.name"
+                data-ng-required="true">
+        </oui-field>
+    </oui-step-form>
 
-    </oui-stepper>
+</oui-stepper>
 
-    <div data-ng-if="$ctrl.loadings.save">
-        <oui-spinner></oui-spinner>
-        <p data-translate="pci_projects_project_storages_containers_add_save_form"></p>
-    </div>
+<div data-ng-if="$ctrl.isLoading">
+    <oui-spinner></oui-spinner>
+    <p data-translate="pci_projects_project_storages_containers_add_save_form"></p>
 </div>

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/index.js
@@ -7,12 +7,14 @@ import 'ovh-ui-angular';
 import 'ovh-api-services';
 import 'angular-ui-bootstrap';
 
+import regionsList from '../../blocks/add/regions-list';
 import component from './add.component';
 
 const moduleName = 'ovhManagerPciStoragesContainersAdd';
 
 angular
   .module(moduleName, [
+    regionsList,
     'ngTranslateAsyncLoader',
     'oui',
     'ovh-api-services',

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/translations/Messages_fr_FR.json
@@ -1,5 +1,4 @@
 {
-  "pci_projects_project_storages_containers_add_back_label": "Retour",
   "pci_projects_project_storages_containers_add_title": "Créer un conteneur d'objets",
   "pci_projects_project_storages_containers_add_region_title": "Sélectionnez une localisation",
   "pci_projects_project_storages_containers_add_type_title": "Sélectionnez un type de conteneur",
@@ -15,7 +14,6 @@
   "pci_projects_project_storages_containers_add_cancel_label": "Annuler",
   "pci_projects_project_storages_containers_add_save_form": "Création du conteneur en cours",
 
-  "pci_projects_project_storages_containers_add_error_query": "Une erreur est survenue lors de la récupération des régions : {{ message }}",
-  "pci_projects_project_storages_containers_add_success_message": "Le conteneur {{container}} a été ajouté",
-  "pci_projects_project_storages_containers_add_error_post": "Une erreur est survenue lors de l'ajout du conteneur {{ container }} : {{ message }}"
+  "pci_projects_project_storages_containers_add_success_message": "Le conteneur {{container}} a été ajouté.",
+  "pci_projects_project_storages_containers_add_error_post": "Une erreur est survenue lors de l'ajout du conteneur {{ container }} : {{ message }}."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container.class.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container.class.js
@@ -1,6 +1,12 @@
+import find from 'lodash/find';
+
 export default class Container {
   constructor(resource) {
     this.publicUrl = null;
     Object.assign(this, resource);
+  }
+
+  getObjectById(objectId) {
+    return find(this.objects, { name: objectId });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.component.js
@@ -8,7 +8,10 @@ export default {
     archive: '<',
     projectId: '<',
     containerId: '<',
+    container: '<',
+    defaultPassword: '<?',
     addObject: '<',
     deleteObject: '<',
+    refresh: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.controller.js
@@ -6,14 +6,12 @@ export default class PciStoragesContainersContainerController {
   /* @ngInject */
   constructor(
     $q,
-    $rootScope,
     $translate,
     $window,
     CucCloudMessage,
     PciProjectStorageContainersService,
   ) {
     this.$q = $q;
-    this.$rootScope = $rootScope;
     this.$translate = $translate;
     this.$window = $window;
     this.CucCloudMessage = CucCloudMessage;
@@ -23,68 +21,15 @@ export default class PciStoragesContainersContainerController {
   }
 
   $onInit() {
-    this.$rootScope.$on('pci_storages_containers_container_refresh', () => this.refreshContainer());
-
     this.columnsParameters = [{
       name: 'retrievalState',
       hidden: !this.archive,
     }];
 
-    this.containers = null;
-
-    this.isLoading = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.getContainer())
-      .then(() => this.getContainerPassword())
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          `pci_projects_project_storages_containers_container_${this.archive ? 'archive' : 'object'}_error_query`,
-          { message: get(err, 'data.message', '') },
-        ),
-        'pci.projects.project.storages.containers.container',
-      ))
-      .finally(() => {
-        this.isLoading = false;
-      });
-  }
-
-  getContainerPassword() {
-    if (this.archive) {
-      return this.PciProjectStorageContainersService
-        .getArchivePassword(this.projectId, this.container)
-        .then((password) => {
-          this.defaultPassword = password;
-        });
-    }
-    return this.$q.resolve();
-  }
-
-  getContainer() {
-    return this.PciProjectStorageContainersService
-      .getContainer(this.projectId, this.containerId)
-      .then((container) => {
-        this.container = container;
-      });
-  }
-
-  refreshContainer() {
-    this.isLoading = true;
-    return this.getContainer()
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          `pci_projects_project_storages_containers_container_${this.archive ? 'archive' : 'object'}_error_query`,
-          { message: get(err, 'data.message', '') },
-        ),
-        'pci.projects.project.storages.containers.container',
-      ))
-      .finally(() => {
-        this.isLoading = false;
-      });
+    this.loadMessages();
   }
 
   loadMessages() {
-    this.CucCloudMessage.unSubscribe('pci.projects.project.storages.containers.container');
     this.messageHandler = this.CucCloudMessage.subscribe(
       'pci.projects.project.storages.containers.container',
       {
@@ -115,22 +60,17 @@ export default class PciStoragesContainersContainerController {
   unsealObject(object) {
     return this.PciProjectStorageContainersService
       .unsealObject(this.projectId, this.container, object)
-      .then(() => this.refreshContainer())
-      .then(() => this.CucCloudMessage.success(
-        this.$translate.instant(
-          'pci_projects_project_storages_containers_container_archive_success_unseal',
-          {
-            archive: object.name,
-          },
-        ),
-        'pci.projects.project.storages.containers.container',
-      ))
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          'pci_projects_project_storages_containers_container_archive_error_unseal',
-          { message: get(err, 'data.message', '') },
-        ),
-        'pci.projects.project.storages.containers.container',
-      ));
+      .then(() => this.refresh(this.$translate.instant(
+        'pci_projects_project_storages_containers_container_archive_success_unseal',
+        {
+          archive: object.name,
+        },
+      )))
+      .catch(err => this.refresh(this.$translate.instant(
+        'pci_projects_project_storages_containers_container_archive_error_unseal',
+        {
+          message: get(err, 'data.message', ''),
+        },
+      ), 'error'));
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/delete/delete.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/delete/delete.component.js
@@ -8,6 +8,7 @@ export default {
     archive: '<',
     projectId: '<',
     containerId: '<',
+    container: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/delete/delete.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/delete/delete.controller.js
@@ -13,84 +13,27 @@ export default class PciBlockStorageDetailsDeleteController {
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
-
-    this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageContainersService
-        .getContainer(this.projectId, this.containerId))
-      .then((container) => {
-        this.container = container;
-        return this.container;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_containers_container_delete_error_load',
-            { message: get(err, 'data.message', '') },
-          ),
-          'pci.projects.project.storages.containers.delete',
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    return new Promise((resolve) => {
-      this.CucCloudMessage.unSubscribe('pci.projects.project.storages.containers.delete');
-      this.messageHandler = this.CucCloudMessage.subscribe(
-        'pci.projects.project.storages.containers.delete',
-        {
-          onMessage: () => this.refreshMessages(),
-        },
-      );
-      resolve();
-    });
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
+    this.isLoading = false;
   }
 
   deleteStorage() {
-    this.loadings.save = true;
+    this.isLoading = true;
     return this.PciProjectStorageContainersService
       .deleteContainer(this.projectId, this.container)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            'pci_projects_project_storages_containers_container_delete_success_message',
-            {
-              container: this.container.name,
-            },
-          ),
-          'pci.projects.project.storages.containers',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            'pci_projects_project_storages_containers_container_delete_error_delete',
-            {
-              message: get(err, 'data.message', null),
-            },
-          ),
-          'pci.projects.project.storages.containers.delete',
-        );
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_containers_container_delete_success_message',
+        {
+          container: this.container.name,
+        },
+      )))
+      .catch(err => this.goBack(this.$translate.instant(
+        'pci_projects_project_storages_containers_container_delete_error_delete',
+        {
+          message: get(err, 'data.message', null),
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/delete/delete.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/delete/delete.html
@@ -2,13 +2,11 @@
     data-heading="{{ 'pci_projects_project_storages_containers_container_delete_'+ ($ctrl.archive ? 'archive' : 'object') + '_title' | translate }}"
     data-primary-action="$ctrl.deleteStorage()"
     data-primary-label="{{:: 'pci_projects_project_storages_containers_container_delete_submit_label' | translate }}"
-    data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save"
+    data-primary-disabled="$ctrl.isLoading"
     data-secondary-action="$ctrl.goBack()"
     data-secondary-label="{{:: 'pci_projects_project_storages_containers_container_delete_cancel_label' | translate }}"
     data-on-dismiss="$ctrl.goBack()"
-    data-loading="$ctrl.loadings.init">
-
-    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+    data-loading="$ctrl.isLoading">
 
     <div data-ng-if="$ctrl.container">
         <p data-translate="pci_projects_project_storages_containers_container_delete_content"
@@ -19,10 +17,6 @@
             <span data-translate="pci_projects_project_storages_containers_container_delete_object_erase_message"
                 data-ng-if="!$ctrl.archive"></span>
         </oui-message>
-    </div>
-
-    <div data-ng-if="$ctrl.loadings.save" class="text-center">
-        <oui-spinner></oui-spinner>
     </div>
 
 </oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/delete/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/delete/translations/Messages_fr_FR.json
@@ -7,7 +7,6 @@
   "pci_projects_project_storages_containers_container_delete_archive_erase_message": "Toutes les données sur le conteneur d'archive seront perdues.",
   "pci_projects_project_storages_containers_container_delete_object_erase_message": "Toutes les données sur le conteneur d'objet seront perdues.",
 
-  "pci_projects_project_storages_containers_container_delete_error_load": "Une erreur est survenue lors du chargement du conteneur : {{ message }}.",
   "pci_projects_project_storages_containers_container_delete_success_message": "Le conteneur {{ container }} a été supprimé.",
   "pci_projects_project_storages_containers_container_delete_error_delete": "Une erreur est survenue lors de la suppression du conteneur {{ container }} : {{ message }}."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/add.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/add.component.js
@@ -8,6 +8,7 @@ export default {
     archive: '<',
     projectId: '<',
     containerId: '<',
+    container: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/add.controller.js
@@ -4,95 +4,34 @@ export default class PciBlockStorageContainersContainerObjectAddController {
   /* @ngInject */
   constructor(
     $translate,
-    $window,
-    CucCloudMessage,
     PciProjectStorageContainersService,
   ) {
     this.$translate = $translate;
-    this.$window = $window;
-    this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageContainersService = PciProjectStorageContainersService;
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
+    this.isLoading = false;
 
-    this.initLoaders();
-  }
-
-  initLoaders() {
     this.prefix = '/';
     this.files = [];
-
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageContainersService
-        .getContainer(this.projectId, this.containerId))
-      .then((container) => {
-        this.container = container;
-        return this.container;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            `pci_projects_project_storages_containers_container_object_add_${this.archive ? 'archive' : 'object'}_error_load`,
-            { message: get(err, 'data.message', '') },
-          ),
-          'pci.projects.project.storages.containers.container.object.add',
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    return new Promise((resolve) => {
-      this.CucCloudMessage.unSubscribe('pci.projects.project.storages.containers.container.object.add');
-      this.messageHandler = this.CucCloudMessage.subscribe(
-        'pci.projects.project.storages.containers.container.object.add',
-        {
-          onMessage: () => this.refreshMessages(),
-        },
-      );
-      resolve();
-    });
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
   }
 
   addObjects() {
-    this.loadings.save = true;
+    this.isLoading = true;
     return this.PciProjectStorageContainersService
       .addObjects(this.projectId, this.container, this.prefix, this.files)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            `pci_projects_project_storages_containers_container_object_add_${this.archive ? 'archive' : 'object'}_success_message`,
-          ),
-          'pci.projects.project.storages.containers.container',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            `pci_projects_project_storages_containers_container_object_add_${this.archive ? 'archive' : 'object'}_error_delete`,
-            {
-              message: get(err, 'data.message', null),
-            },
-          ),
-          'pci.projects.project.storages.containers.container.object.add',
-        );
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        `pci_projects_project_storages_containers_container_object_add_${this.archive ? 'archive' : 'object'}_success_message`,
+      )))
+      .catch(err => this.goBack(this.$translate.instant(
+        `pci_projects_project_storages_containers_container_object_add_${this.archive ? 'archive' : 'object'}_error_delete`,
+        {
+          message: get(err, 'data.message', null),
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/add.html
@@ -3,13 +3,11 @@
         data-heading="{{ 'pci_projects_project_storages_containers_container_object_add_'+ ($ctrl.archive ? 'archive' : 'object') + '_title' | translate }}"
         data-primary-action="$ctrl.addObjects()"
         data-primary-label="{{:: 'pci_projects_project_storages_containers_container_object_add_submit_label' | translate }}"
-        data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save"
+        data-primary-disabled="$ctrl.isLoading"
         data-secondary-action="$ctrl.goBack()"
         data-secondary-label="{{:: 'pci_projects_project_storages_containers_container_object_add_cancel_label' | translate }}"
         data-on-dismiss="$ctrl.goBack()"
-        data-loading="$ctrl.loadings.init || $ctrl.loadings.save">
-
-        <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+        data-loading="$ctrl.isLoading">
 
         <oui-field data-label="{{:: 'pci_projects_project_storages_containers_container_object_add_prefix_label' | translate }}" data-size="xl">
             <input class="oui-input" type="text" id="lastname" name="prefix" data-ng-model="$ctrl.prefix" required minlength="3" maxlength="32">

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/translations/Messages_fr_FR.json
@@ -7,8 +7,6 @@
   "pci_projects_project_storages_containers_container_object_add_prefix_label": "Préfixe",
   "pci_projects_project_storages_containers_container_object_add_files_label": "Importer des fichiers",
 
-  "pci_projects_project_storages_containers_container_object_add_archive_error_load": "Une erreur est survenue lors du chargement de l'archive : {{ message }}.",
-  "pci_projects_project_storages_containers_container_object_add_object_error_load": "Une erreur est survenue lors du chargement de l'objet : {{ message }}.",
   "pci_projects_project_storages_containers_container_object_add_archive_success_message": "Les archives ont été importées.",
   "pci_projects_project_storages_containers_container_object_add_object_success_message": "Les objets ont été importés.",
   "pci_projects_project_storages_containers_container_object_add_archive_error_delete": "Une erreur est survenue lors de l'import des archives : {{ message }}.",

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/delete/delete.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/delete/delete.component.js
@@ -8,7 +8,9 @@ export default {
     archive: '<',
     projectId: '<',
     containerId: '<',
+    container: '<',
     objectId: '<',
+    object: '<',
     goBack: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/delete/delete.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/delete/delete.controller.js
@@ -4,97 +4,34 @@ export default class PciBlockStorageContainersContainerObjectDeleteController {
   /* @ngInject */
   constructor(
     $translate,
-    $window,
-    CucCloudMessage,
     PciProjectStorageContainersService,
   ) {
     this.$translate = $translate;
-    this.$window = $window;
-    this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageContainersService = PciProjectStorageContainersService;
   }
 
   $onInit() {
-    this.loadings = {
-      init: false,
-      save: false,
-    };
-
-    this.initLoaders();
-  }
-
-  initLoaders() {
-    this.loadings.init = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.PciProjectStorageContainersService
-        .getObject(this.projectId, this.containerId, this.objectId))
-      .then(({ container, object }) => {
-        this.object = object;
-        this.container = container;
-
-        return this.object;
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            `pci_projects_project_storages_containers_container_object_delete_${this.archive ? 'archive' : 'object'}_error_load`,
-            { message: get(err, 'data.message', '') },
-          ),
-          'pci.projects.project.storages.containers.container.object.delete',
-        );
-      })
-      .finally(() => {
-        this.loadings.init = false;
-      });
-  }
-
-  loadMessages() {
-    return new Promise((resolve) => {
-      this.CucCloudMessage.unSubscribe('pci.projects.project.storages.containers.container.object.delete');
-      this.messageHandler = this.CucCloudMessage.subscribe(
-        'pci.projects.project.storages.containers.container.object.delete',
-        {
-          onMessage: () => this.refreshMessages(),
-        },
-      );
-      resolve();
-    });
-  }
-
-  refreshMessages() {
-    this.messages = this.messageHandler.getMessages();
+    this.isLoading = false;
   }
 
   deleteObject() {
-    this.loadings.save = true;
+    this.isLoading = true;
     return this.PciProjectStorageContainersService
       .deleteObject(this.projectId, this.container, this.object)
-      .then(() => {
-        this.CucCloudMessage.success(
-          this.$translate.instant(
-            `pci_projects_project_storages_containers_container_object_delete_${this.archive ? 'archive' : 'object'}_success_message`,
-            {
-              object: this.object.name,
-            },
-          ),
-          'pci.projects.project.storages.containers.container',
-        );
-        return this.goBack(true);
-      })
-      .catch((err) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant(
-            `pci_projects_project_storages_containers_container_object_delete_${this.archive ? 'archive' : 'object'}_error_delete`,
-            {
-              message: get(err, 'data.message', null),
-            },
-          ),
-          'pci.projects.project.storages.containers.container.object.delete',
-        );
-      })
+      .then(() => this.goBack(this.$translate.instant(
+        `pci_projects_project_storages_containers_container_object_delete_${this.archive ? 'archive' : 'object'}_success_message`,
+        {
+          object: this.object.name,
+        },
+      )))
+      .catch(err => this.goBack(this.$translate.instant(
+        `pci_projects_project_storages_containers_container_object_delete_${this.archive ? 'archive' : 'object'}_error_delete`,
+        {
+          message: get(err, 'data.message', null),
+        },
+      ), 'error'))
       .finally(() => {
-        this.loadings.save = false;
+        this.isLoading = false;
       });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/delete/delete.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/delete/delete.html
@@ -2,13 +2,11 @@
     data-heading="{{ 'pci_projects_project_storages_containers_container_object_delete_'+ ($ctrl.archive ? 'archive' : 'object') + '_title' | translate }}"
     data-primary-action="$ctrl.deleteObject()"
     data-primary-label="{{:: 'pci_projects_project_storages_containers_container_object_delete_submit_label' | translate }}"
-    data-primary-disabled="$ctrl.loadings.init || $ctrl.loadings.save"
+    data-primary-disabled="$ctrl.isLoading"
     data-secondary-action="$ctrl.goBack()"
     data-secondary-label="{{:: 'pci_projects_project_storages_containers_container_object_delete_cancel_label' | translate }}"
     data-on-dismiss="$ctrl.goBack()"
-    data-loading="$ctrl.loadings.init || $ctrl.loadings.save">
-
-    <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+    data-loading="$ctrl.isLoading">
 
     <p data-translate="pci_projects_project_storages_containers_container_object_delete_content"
         data-translate-values="{ object: $ctrl.object.name }"></p>

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/delete/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/delete/translations/Messages_fr_FR.json
@@ -5,10 +5,8 @@
   "pci_projects_project_storages_containers_container_object_delete_cancel_label": "Annuler",
   "pci_projects_project_storages_containers_container_object_delete_content": "Voulez-vous supprimer {{ object }} ?",
 
-  "pci_projects_project_storages_containers_container_object_delete_archive_error_load": "Une erreur est survenue lors du chargement de l'archive : {{ message }}",
-  "pci_projects_project_storages_containers_container_object_delete_object_error_load": "Une erreur est survenue lors du chargement de l'objet : {{ message }}",
-  "pci_projects_project_storages_containers_container_object_delete_archive_success_message": "L'archive {{ object }} a été supprimée",
-  "pci_projects_project_storages_containers_container_object_delete_object_success_message": "L'objet {{ object }} a été supprimé",
-  "pci_projects_project_storages_containers_container_object_delete_archive_error_delete": "Une erreur est survenue lors de la suppression de l'archive {{ object }} : {{ message }}",
-  "pci_projects_project_storages_containers_container_object_delete_object_error_delete": "Une erreur est survenue lors de la suppression de l'objet {{ object }} : {{ message }}"
+  "pci_projects_project_storages_containers_container_object_delete_archive_success_message": "L'archive {{ object }} a été supprimée.",
+  "pci_projects_project_storages_containers_container_object_delete_object_success_message": "L'objet {{ object }} a été supprimé.",
+  "pci_projects_project_storages_containers_container_object_delete_archive_error_delete": "Une erreur est survenue lors de la suppression de l'archive {{ object }} : {{ message }}.",
+  "pci_projects_project_storages_containers_container_object_delete_object_error_delete": "Une erreur est survenue lors de la suppression de l'objet {{ object }} : {{ message }}."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/containers.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/containers.component.js
@@ -6,9 +6,12 @@ export default {
   template,
   bindings: {
     projectId: '<',
+    containers: '<',
     addContainer: '<',
     viewContainer: '<',
     deleteContainer: '<',
+    containerLink: '<',
+    goToStorageContainers: '<',
     archive: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/containers.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/containers.controller.js
@@ -1,56 +1,18 @@
-import get from 'lodash/get';
-
 export default class PciStoragesContainersController {
   /* @ngInject */
   constructor(
-    $rootScope,
     $translate,
     CucCloudMessage,
-    PciProjectStorageContainersService,
   ) {
-    this.$rootScope = $rootScope;
     this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
-    this.PciProjectStorageContainersService = PciProjectStorageContainersService;
   }
 
   $onInit() {
-    this.$rootScope.$on('pci_storages_containers_refresh', () => this.refreshContainers());
-
-    this.containers = null;
-
-    this.isLoading = true;
-    return this.$translate.refresh()
-      .then(() => this.loadMessages())
-      .then(() => this.getContainers())
-      .finally(() => {
-        this.isLoading = false;
-      });
-  }
-
-  getContainers() {
-    return this.PciProjectStorageContainersService.getAll(this.projectId, this.archive)
-      .then((containers) => {
-        this.containers = containers;
-      })
-      .catch(err => this.CucCloudMessage.error(
-        this.$translate.instant(
-          'pci_projects_project_storages_containers_error_query',
-          { message: get(err, 'data.message', '') },
-        ),
-      ));
-  }
-
-  refreshContainers() {
-    this.isLoading = true;
-    return this.getContainers()
-      .finally(() => {
-        this.isLoading = false;
-      });
+    this.loadMessages();
   }
 
   loadMessages() {
-    this.CucCloudMessage.unSubscribe('pci.projects.project.storages.containers');
     this.messageHandler = this.CucCloudMessage.subscribe(
       'pci.projects.project.storages.containers',
       {

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/containers.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/containers.html
@@ -15,7 +15,7 @@
                 data-searchable
                 data-sortable="asc"
                 data-filterable>
-                <span data-ng-bind="::$value" class="text-truncate"></span>
+                <a data-ng-href="{{:: $ctrl.containerLink($row) }}" data-ng-bind="::$value" class="text-truncate"></a>
             </oui-column>
             <oui-column
                 data-title="'pci_projects_project_storages_containers_region_label' | translate"

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/containers.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/containers.service.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import find from 'lodash/find';
 import has from 'lodash/has';
 import map from 'lodash/map';
 import pickBy from 'lodash/pickBy';
@@ -246,22 +245,20 @@ export default class PciStoragesContainersService {
       });
   }
 
-  deleteContainer(projectId, { id }) {
-    return this.OvhApiCloudProjectStorage
-      .v6()
-      .delete({
-        projectId,
-        containerId: id,
-      })
-      .$promise;
-  }
+  deleteContainer(projectId, container) {
+    const promises = reduce(container.objects, (result, object) => [
+      ...result,
+      this.deleteObject(projectId, container, object),
+    ], []);
 
-  getObject(projectId, containerId, objectId) {
-    return this.getContainer(projectId, containerId)
-      .then(container => ({
-        container,
-        object: find(container.objects, { name: objectId }),
-      }));
+    return this.$q.all(promises)
+      .then(() => this.OvhApiCloudProjectStorage
+        .v6()
+        .delete({
+          projectId,
+          containerId: container.id,
+        })
+        .$promise);
   }
 
   static getFilePath(filePrefix, file) {

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/translations/Messages_fr_FR.json
@@ -17,7 +17,6 @@
   "pci_projects_project_storages_containers_delete_label": "Supprimer",
 
   "pci_projects_project_storages_blocks_add_archive_label": "Créer un conteneur d'archive",
-  "pci_projects_project_storages_blocks_add_object_label": "Créer un conteneur d'objets",
+  "pci_projects_project_storages_blocks_add_object_label": "Créer un conteneur d'objets"
 
-  "pci_projects_project_storages_containers_error_query": "Une erreur est survenue lors de la récupération des conteneurs."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/objects/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/objects/add/add.routing.js
@@ -4,17 +4,18 @@ export default /* @ngInject */ ($stateProvider) => {
       url: '/new',
       component: 'pciProjectStorageContainersAdd',
       resolve: {
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_containers_refresh');
-          }
-          return $state.go('pci.projects.project.storages.objects', {
-            projectId,
-          });
-        },
+        regions: /* @ngInject */ (
+          PciProjectStorageBlockService,
+          projectId,
+        ) => PciProjectStorageBlockService.getAvailablesRegions(projectId),
+        goBack: /* @ngInject */ goToStorageContainers => goToStorageContainers,
         cancelLink: /* @ngInject */ ($state, projectId) => $state.href('pci.projects.project.storages.objects', {
           projectId,
         }),
+
+        breadcrumb: /* @ngInject */ $translate => $translate
+          .refresh()
+          .then(() => $translate.instant('pci_projects_project_storages_containers_add_title')),
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/objects/object/delete/delete.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/objects/object/delete/delete.routing.js
@@ -10,14 +10,12 @@ export default /* @ngInject */ ($stateProvider) => {
       layout: 'modal',
       resolve: {
         containerId: /* @ngInject */$transition$ => $transition$.params().containerId,
-        goBack: /* @ngInject */ ($rootScope, $state, projectId) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_containers_refresh');
-          }
-          return $state.go('pci.projects.project.storages.objects', {
-            projectId,
-          });
-        },
+        container: /* @ngInject */ (
+          PciProjectStorageContainersService,
+          projectId,
+          containerId,
+        ) => PciProjectStorageContainersService.getContainer(projectId, containerId),
+        goBack: /* @ngInject */ goToStorageContainers => goToStorageContainers,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/objects/object/object.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/objects/object/object.routing.js
@@ -5,6 +5,12 @@ export default /* @ngInject */ ($stateProvider) => {
       component: 'pciProjectStorageContainersContainer',
       resolve: {
         containerId: /* @ngInject */ $transition$ => $transition$.params().containerId,
+        container: /* @ngInject */ (
+          PciProjectStorageContainersService,
+          projectId,
+          containerId,
+        ) => PciProjectStorageContainersService.getContainer(projectId, containerId),
+
         addObject: /* @ngInject */ ($state, projectId, containerId) => () => $state.go('pci.projects.project.storages.objects.object.add', {
           projectId,
           containerId,
@@ -14,6 +20,29 @@ export default /* @ngInject */ ($stateProvider) => {
           containerId,
           objectId: object.name,
         }),
+        goBack: /* @ngInject */ goToStorageContainers => goToStorageContainers,
+
+        goToStorageContainer: /* @ngInject */ ($rootScope, CucCloudMessage, $state, projectId, containerId) => (message = false, type = 'success') => {
+          const reload = message && type === 'success';
+
+          const promise = $state.go('pci.projects.project.storages.objects.object', {
+            projectId,
+            containerId,
+          },
+          {
+            reload,
+          });
+
+          if (message) {
+            promise.then(() => CucCloudMessage[type](message, 'pci.projects.project.storages.containers.container'));
+          }
+
+          return promise;
+        },
+
+        refresh: /* @ngInject */ goToStorageContainer => goToStorageContainer,
+
+        breadcrumb: /* @ngInject */ container => container.name,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/objects/object/object/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/objects/object/object/add/add.routing.js
@@ -9,20 +9,7 @@ export default /* @ngInject */ ($stateProvider) => {
       },
       layout: 'modal',
       resolve: {
-        goBack: /* @ngInject */ (
-          $rootScope,
-          $state,
-          projectId,
-          containerId,
-        ) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_containers_container_refresh');
-          }
-          return $state.go('pci.projects.project.storages.objects.object', {
-            projectId,
-            containerId,
-          });
-        },
+        goBack: /* @ngInject */ goToStorageContainer => goToStorageContainer,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/objects/object/object/delete/delete.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/objects/object/object/delete/delete.routing.js
@@ -10,20 +10,12 @@ export default /* @ngInject */ ($stateProvider) => {
       layout: 'modal',
       resolve: {
         objectId: /* @ngInject */$transition$ => $transition$.params().objectId,
-        goBack: /* @ngInject */ (
-          $rootScope,
-          $state,
-          projectId,
-          containerId,
-        ) => (reload = false) => {
-          if (reload) {
-            $rootScope.$emit('pci_storages_containers_container_refresh');
-          }
-          return $state.go('pci.projects.project.storages.objects.object', {
-            projectId,
-            containerId,
-          });
-        },
+        object: /* @ngInject */ (
+          container,
+          objectId,
+        ) => container.getObjectById(objectId),
+
+        goBack: /* @ngInject */ goToStorageContainer => goToStorageContainer,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/objects/objects.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/objects/objects.routing.js
@@ -5,6 +5,11 @@ export default /* @ngInject */ ($stateProvider) => {
       component: 'pciProjectStorageContainers',
       resolve: {
         archive: () => false,
+        containers: /* @ngInject */ (
+          PciProjectStorageContainersService,
+          archive,
+          projectId,
+        ) => PciProjectStorageContainersService.getAll(projectId, archive),
         addContainer: /* @ngInject */($state, projectId) => () => $state.go('pci.projects.project.storages.objects.add', {
           projectId,
         }),
@@ -16,6 +21,28 @@ export default /* @ngInject */ ($stateProvider) => {
           projectId,
           containerId: container.id,
         }),
+        containerLink: /* @ngInject */($state, projectId) => container => $state.href('pci.projects.project.storages.objects.object', {
+          projectId,
+          containerId: container.id,
+        }),
+
+        goToStorageContainers: /* @ngInject */ ($rootScope, CucCloudMessage, $state, projectId) => (message = false, type = 'success') => {
+          const reload = message && type === 'success';
+
+          const promise = $state.go('pci.projects.project.storages.objects', {
+            projectId,
+          },
+          {
+            reload,
+          });
+
+          if (message) {
+            promise.then(() => CucCloudMessage[type](message, 'pci.projects.project.storages.containers'));
+          }
+
+          return promise;
+        },
+
         breadcrumb: /* @ngInject */ $translate => $translate
           .refresh()
           .then(() => $translate.instant('pci_projects_project_storages_containers_object_title')),


### PR DESCRIPTION
## fix: update containers storages

### Description of the Change

- remove `CucCloudMessage` listener in modals
- add `goToStorageContainers` & `goToStorageContainer`  resolve and use it in `goBack` sub resolve 
  - navigate to containers/objects list and trigger a `CucCloudMessage`
  - if the message is a `success` message, `$state.go` is called with `reload: true` option
- move initial data loading in `resolve` and remove related code/translations
- Fix translations (wording)
- import `regions-list` in containers add form (broken since lazy loading in `block storages`)
- fix container deletion (delete all container's objects before calling container's delete API)
- add missing `breadcrumb`

1e0bac93 — fix: update containers storages


/cc @jleveugle @marie-j 
