### PR TITLE
feat(pci.project.failover-ips): add empty page

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.component.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.component.js
@@ -1,0 +1,11 @@
+import controller from './failover-ips.controller';
+import template from './failover-ips.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    projectId: '<',
+    failoverIps: '<',
+  },
+};

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.controller.js
@@ -2,39 +2,16 @@ const MESSAGES_CONTAINER_NAME = 'pci.projects.project.failover-ips';
 
 export default class FailoverIpController {
   /* @ngInject */
-  constructor($translate, CucCloudMessage, OvhApiCloudProjectIpFailover, projectId) {
+  constructor($translate, CucCloudMessage, OvhApiCloudProjectIpFailover) {
     this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
     this.OvhApiCloudProjectIpFailover = OvhApiCloudProjectIpFailover;
-    this.projectId = projectId;
-
-    this.messageHandler = CucCloudMessage.subscribe(MESSAGES_CONTAINER_NAME, {
-      onMessage: () => this.refreshMessage(),
-    });
   }
 
-  loadPartialData({ offset, pageSize }) {
-    return this.OvhApiCloudProjectIpFailover
-      .v6()
-      .query({
-        serviceName: this.projectId,
-      })
-      .$promise
-      .then(data => ({
-        data: data.slice(offset - 1, offset + pageSize - 1),
-        meta: {
-          totalCount: data.length,
-          currentOffset: offset,
-          pageCount: Math.ceil(data.length / pageSize),
-          pageSize,
-        },
-      }))
-      .catch(({ data }) => {
-        this.CucCloudMessage.error(
-          this.$translate.instant('pci_projects_project_failoverip_error', { error: data.message }),
-          MESSAGES_CONTAINER_NAME,
-        );
-      });
+  $onInit() {
+    this.messageHandler = this.CucCloudMessage.subscribe(MESSAGES_CONTAINER_NAME, {
+      onMessage: () => this.refreshMessage(),
+    });
   }
 
   refreshMessage() {

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.html
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.html
@@ -2,7 +2,7 @@
     <h1 data-translate="pci_projects_project_failoverip_title"></h1>
     <div>
         <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
-        <oui-datagrid data-rows-loader="$ctrl.loadPartialData($config)" data-page-size="5">
+        <oui-datagrid data-rows="$ctrl.failoverIps" data-page-size="5">
             <extra-top>
                 <a class="oui-button oui-button_secondary oui-button_icon-left mb-3" data-ui-sref="pci.projects.project.failover-ips.imports">
                     <span class="oui-icon oui-icon-add" aria-hidden="true"></span>

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.module.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.module.js
@@ -4,6 +4,9 @@ import '@uirouter/angularjs';
 
 import failoverIp from './failover-ip';
 import imports from './imports';
+import onboarding from './onboarding';
+
+import component from './failover-ips.component';
 import routing from './failover-ips.routing';
 
 const moduleName = 'ovhManagerPciProjectFailoverIps';
@@ -14,7 +17,9 @@ angular
     'pascalprecht.translate',
     failoverIp,
     imports,
+    onboarding,
   ])
-  .config(routing);
+  .config(routing)
+  .component('pciProjectFailoverIps', component);
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ips.routing.js
@@ -1,21 +1,29 @@
-import controller from './failover-ips.controller';
-import template from './failover-ips.html';
-
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider
     .state('pci.projects.project.failover-ips', {
       url: '/failover-ips',
-      controller,
-      controllerAs: '$ctrl',
-      template,
+      component: 'pciProjectFailoverIps',
       translations: {
         format: 'json',
         value: ['.'],
       },
+      redirectTo: transition => transition
+        .injector()
+        .getAsync('failoverIps')
+        .then(failoverIps => (failoverIps.length === 0 ? { state: 'pci.projects.project.failover-ips.onboarding' } : false)),
       resolve: {
         breadcrumb: /* @ngInject */ $translate => $translate
           .refresh()
           .then(() => $translate.instant('pci_projects_project_failoverip_title')),
+        failoverIps: /* @ngInject */ (
+          OvhApiCloudProjectIpFailover,
+          projectId,
+        ) => OvhApiCloudProjectIpFailover
+          .v6()
+          .query({
+            serviceName: projectId,
+          })
+          .$promise,
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/index.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/index.js
@@ -1,0 +1,24 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+
+const moduleName = 'ovhManagerPciFailoverIpsOnboardingLazyLoading';
+
+angular
+  .module(moduleName, [
+    'ui.router',
+    'oc.lazyLoad',
+  ])
+  .config(/* @ngInject */ ($stateProvider) => {
+    $stateProvider.state('pci.projects.project.failover-ips.onboarding.**', {
+      url: '/onboarding',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./onboarding.module')
+          .then(mod => $ocLazyLoad.inject(mod.default || mod));
+      },
+    });
+  });
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.component.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.component.js
@@ -1,0 +1,10 @@
+import controller from './onboarding.controller';
+import template from './onboarding.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    addFailoverIp: '<',
+  },
+};

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.constants.js
@@ -1,0 +1,12 @@
+export const GUIDES = [
+  {
+    id: 'persistent-failover-ip-configuration',
+    link: 'https://docs.ovh.com/gb/en/public-cloud/make-failover-ip-configuration-persistent/',
+  },
+  {
+    id: 'migrating-failover-ip',
+    link: 'https://docs.ovh.com/gb/en/public-cloud/migrating_a_failover_ip/',
+  },
+];
+
+export default { GUIDES };

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.controller.js
@@ -1,0 +1,26 @@
+import reduce from 'lodash/reduce';
+import { GUIDES } from './onboarding.constants';
+
+export default class PciFailoverIpsOnboardingController {
+  /* @ngInject */
+  constructor(
+    $translate,
+  ) {
+    this.$translate = $translate;
+  }
+
+  $onInit() {
+    this.guides = reduce(
+      GUIDES,
+      (list, guide) => ([
+        ...list,
+        {
+          ...guide,
+          title: this.$translate.instant(`pci_projects_project_failoverip_onboarding_guides_${guide.id}_title`),
+          description: this.$translate.instant(`pci_projects_project_failoverip_onboarding_guides_${guide.id}_description`),
+        },
+      ]),
+      [],
+    );
+  }
+}

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.html
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.html
@@ -1,0 +1,14 @@
+<pci-project-empty guides="$ctrl.guides">
+    <h1 data-translate="pci_projects_project_failoverip_title"></h1>
+    <p data-translate="pci_projects_project_failoverip_onboarding_content1"></p>
+    <strong data-translate="pci_projects_project_failoverip_onboarding_content2"></strong>
+    <p data-translate="pci_projects_project_failoverip_onboarding_content3"></p>
+    <p data-translate="pci_projects_project_failoverip_onboarding_content4"></p>
+
+    <oui-button
+        data-variant="primary"
+        data-on-click="$ctrl.addFailoverIp()">
+        <span data-translate="pci_projects_project_failoverip_onboarding_action_label"></span>
+    </oui-button>
+
+</pci-project-empty>

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.module.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.module.js
@@ -1,0 +1,26 @@
+import angular from 'angular';
+import '@ovh-ux/ng-translate-async-loader';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-ui-angular';
+
+import component from './onboarding.component';
+import routing from './onboarding.routing';
+
+import empty from '../../../../components/project/empty';
+
+const moduleName = 'ovhManagerPciFailoverIpsOnboarding';
+
+angular
+  .module(moduleName, [
+    empty,
+    'ui.router',
+    'oui',
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+  ])
+  .config(routing)
+  .component('pciProjectFailoverIpsOnboarding', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/onboarding.routing.js
@@ -1,0 +1,17 @@
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider
+    .state('pci.projects.project.failover-ips.onboarding', {
+      url: '/onboarding',
+      component: 'pciProjectFailoverIpsOnboarding',
+      resolve: {
+        breadcrumb: () => null, // Hide breadcrumb
+        addFailoverIp: /* @ngInject */ ($state, projectId) => () => $state.go('pci.projects.project.failover-ips.imports', {
+          projectId,
+        }),
+      },
+      translations: {
+        value: ['.'],
+        format: 'json',
+      },
+    });
+};

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/onboarding/translations/Messages_fr_FR.json
@@ -1,0 +1,12 @@
+{
+  "pci_projects_project_failoverip_onboarding_content1": "Vous n'avez pas encore créé d’IP fail-over.",
+  "pci_projects_project_failoverip_onboarding_content2": "Attribuez et déplacez vos IP publiques d'une instance à une autre.",
+  "pci_projects_project_failoverip_onboarding_content3": "Grâce aux IP fail-over, vous pouvez faire pointer une adresse IP publique sur une instance puis la faire basculer vers une autre instance de votre projet à tout instant. Ce service est particulièrement utile pour gérer des opérations de maintenance ou de mise à jour.",
+  "pci_projects_project_failoverip_onboarding_content4": "À noter qu’une configuration système est nécessaire pour utiliser une IP fail-over.",
+  "pci_projects_project_failoverip_onboarding_action_label": "Importer une IP Failover",
+
+  "pci_projects_project_failoverip_onboarding_guides_persistent-failover-ip-configuration_title": "Rendre la configuration IP Fail Over persistante",
+  "pci_projects_project_failoverip_onboarding_guides_persistent-failover-ip-configuration_description": "",
+  "pci_projects_project_failoverip_onboarding_guides_migrating-failover-ip_title": "Basculer une IP Fail Over",
+  "pci_projects_project_failoverip_onboarding_guides_migrating-failover-ip_description": ""
+}

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/translations/Messages_fr_FR.json
@@ -5,6 +5,5 @@
   "pci_projects_project_failoverip_id": "Service associé",
   "pci_projects_project_failoverip_routedTo": "Instance associée",
   "pci_projects_project_failoverip_import": "Importer une IP",
-  "pci_projects_project_failoverip_error": "Une erreur est survenue lors de la récupération des IP Failover ({{ error }}).",
   "pci_projects_project_failoverip_edit": "Modifier l'instance associée"
 }


### PR DESCRIPTION
## feat(pci.project.failover-ips): add empty page

### Description of the Change

* add `onboarding`module
* update `failoverIps` to use component and resolve
* redirect to `onboarding` if no `failoverIps`

7f287773 — feat(pci.project.failover-ips): add empty page

ref: MANAGER-2280
