### PR TITLE
fix(sms.options): reset notification sender on change type

### DIFF
--- a/packages/manager/modules/sms/src/options/response/edit/telecom-sms-options-response-edit.controller.js
+++ b/packages/manager/modules/sms/src/options/response/edit/telecom-sms-options-response-edit.controller.js
@@ -86,6 +86,7 @@ export default class {
    * Reset tracking options.
    */
   resetTrackingOptions() {
+    this.trackingSender.sender = null;
     this.model.option.sender = '';
     this.model.option.target = '';
   }


### PR DESCRIPTION
# Reset sender value on type of notification change

### :bug: Bug Fix

- 737e084 fix(sms.options): reset notification sender on change type

Ref : MBE-251