### PR TITLE
fix(pci): add missing ng-uirouter-breadcrumb peer dependency

### DIFF
--- a/packages/components/ng-uirouter-breadcrumb/README.md
+++ b/packages/components/ng-uirouter-breadcrumb/README.md
@@ -12,11 +12,11 @@ yarn add @ovh-ux/ng-uirouter-breadcrumb
 
 ```js
 import angular from 'angular';
-import ngUiRouterBreadcrumb from '@ovh-ux/ng-uirouter-breadcrumb';
+import ngUirouterBreadcrumb from '@ovh-ux/ng-uirouter-breadcrumb';
 
 angular
   .module('myApp', [
-    ngUiRouterBreadcrumb,
+    ngUirouterBreadcrumb,
   ]);
 ```
 

--- a/packages/manager/apps/public-cloud/src/index.js
+++ b/packages/manager/apps/public-cloud/src/index.js
@@ -24,7 +24,7 @@ import ovhManagerPci from '@ovh-ux/manager-pci';
 import ngOvhApiWrappers from '@ovh-ux/ng-ovh-api-wrappers';
 import ngOvhOtrs from '@ovh-ux/ng-ovh-otrs';
 import ngOvhUserPref from '@ovh-ux/ng-ovh-user-pref';
-import ngUiRouterBreadcrumb from '@ovh-ux/ng-uirouter-breadcrumb';
+import ngUirouterBreadcrumb from '@ovh-ux/ng-uirouter-breadcrumb';
 import ngUiRouterLineProgress from '@ovh-ux/ng-uirouter-line-progress';
 
 import 'ovh-ui-kit/dist/oui.css';
@@ -49,7 +49,7 @@ angular
     uiRouter,
     atInternet,
     betaWarning,
-    ngUiRouterBreadcrumb,
+    ngUirouterBreadcrumb,
     ngUiRouterLineProgress,
     ovhManagerCore,
     ovhManagerPci,

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -55,6 +55,7 @@
     "@ovh-ux/ng-ovh-toaster": "^1.0.2",
     "@ovh-ux/ng-ovh-user-pref": "^1.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
+    "@ovh-ux/ng-uirouter-breadcrumb": "^0.0.0",
     "@ovh-ux/ng-uirouter-layout": "^0.1.0",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",

--- a/packages/manager/modules/pci/src/index.js
+++ b/packages/manager/modules/pci/src/index.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import 'angular-animate';
 import '@ovh-ux/manager-core';
 import '@uirouter/angularjs';
+import '@ovh-ux/ng-uirouter-breadcrumb';
 import '@ovh-ux/ng-uirouter-layout';
 import 'oclazyload';
 import '@ovh-ux/ng-at-internet';
@@ -70,6 +71,7 @@ angular
     'ngOvhUserPref',
     'ngOvhSwimmingPoll',
     'ngOvhDocUrl',
+    'ngUirouterBreadcrumb',
     'ngUiRouterLayout',
     'ngAtInternet',
     'ovh-api-services',


### PR DESCRIPTION
# Add missing peer dependency

### :bug: Bug Fix

1f0ef42 - fix(pci): add missing ng-uirouter-breadcrumb peer dependency
0157eb1 - fix(apps.public-cloud): update assigniationfrom uirouter-breadcrumb

### :memo: Documentation

b0bafa5 - docs(components.uirouter.breadcrumb): update usage part

### :house: Internal

- No QC required.

ref: https://github.com/ovh-ux/manager/blob/develop/packages/manager/modules/pci/src/projects/project/project.html#L14