### PR TITLE
fix(pci.project.instance): set default instance billing to hourly

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
@@ -29,7 +29,7 @@ export default class PciInstancesAddController {
 
   $onInit() {
     this.instance = new Instance({
-      monthlyBilling: true,
+      monthlyBilling: false,
     });
 
     this.isLoading = false;


### PR DESCRIPTION
## fix(pci.project.instance): set default instance billing to hourly

### Description of the Change


455a38fe — fix(pci.project.instance): set default instance billing to hourly

ref: MSB-28
