### PR TITLE
refactor: remove unused ovh-jquery-ui-draggable-ng dependency

### DIFF
--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -45,7 +45,6 @@
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
     "ovh-api-services": "^6.17.0",
     "ovh-common-style": "^5.0.0",
-    "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.0.1",
     "ovh-ui-kit": "^2.32.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -60,7 +60,6 @@
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
     "ovh-api-services": "^6.17.0",
     "ovh-common-style": "^5.0.0",
-    "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.0.1",
     "ovh-ui-kit": "^2.32.0",

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -67,7 +67,6 @@
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
     "ovh-api-services": "^6.12.0",
     "ovh-common-style": "^5.0.0",
-    "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-angular": "^2.29.0",
     "ovh-ui-kit": "^2.29.0",

--- a/packages/manager/modules/pci/src/index.js
+++ b/packages/manager/modules/pci/src/index.js
@@ -15,7 +15,6 @@ import '@ovh-ux/ng-ovh-form-flat';
 import '@ovh-ux/ng-ovh-api-wrappers'; // should be a peer dependency of ovh-api-services
 import 'ovh-api-services';
 import 'ovh-ui-angular';
-import 'ovh-jquery-ui-draggable-ng';
 import 'ovh-angular-q-allsettled';
 import 'ovh-angular-pagination-front';
 import 'angular-ui-bootstrap';
@@ -74,7 +73,6 @@ angular
     'ngUiRouterLayout',
     'ngAtInternet',
     'ovh-api-services',
-    'ovh-jquery-ui-draggable-ng',
     'ovh-angular-q-allSettled',
     'ovh-angular-pagination-front',
     'oui',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9142,10 +9142,6 @@ ovh-common-style@^5.0.0:
   resolved "https://registry.yarnpkg.com/ovh-common-style/-/ovh-common-style-5.0.0.tgz#f99c19bdb78d3b5fba4ab7b1437229f430e2a282"
   integrity sha512-qe2fV+pLEFEJdZOlM33N3Rmlg582kJgc+b+E5/U8W56FkFYIxS3Lmvi1QrN/+ig7SKwt6ftvPmKLBbwwcGkKPQ==
 
-ovh-jquery-ui-draggable-ng@ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5:
-  version "0.0.5"
-  resolved "https://codeload.github.com/ovh-ux/ovh-jquery-ui-draggable-ng/tar.gz/1534d99081af3e8533049c20d940a50595bdc916"
-
 ovh-manager-webfont@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ovh-manager-webfont/-/ovh-manager-webfont-1.2.0.tgz#e59e89e6248b7bf97b204bb18521b2f5bd347961"


### PR DESCRIPTION
# Remove unused dependency

Since #521 remove the entire legacy part, this following dependency could
be removed.

It contains:

- draggable

### :nail_care: Refactor

4a60b77 - refactor: remove unused ovh-jquery-ui-draggable-ng dependency

### :house: Internal

- No QC required.

ref: #521