### PR TITLE
fix(pci): prevent firefox padding-bottom removal with overflow

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/project.html
+++ b/packages/manager/modules/pci/src/projects/project/project.html
@@ -4,9 +4,9 @@
             <cloud-sidebar></cloud-sidebar>
         </div>
         <div class="h-100 position-relative p-0 col-md-10">
-            <div class="pci-project-content position-absolute w-100 h-100 py-4 px-5" style="overflow: auto;">
+            <div class="pci-project-content position-absolute w-100 h-100 pt-4 px-5" style="overflow: auto;">
                 <uirouter-breadcrumb></uirouter-breadcrumb>
-                <div class="pci-project-view mt-3" data-ui-view>
+                <div class="pci-project-view mt-3 pb-4" data-ui-view>
                     <div data-ng-if="$ctrl.project">
                         <oui-page-header heading="{{ ::$ctrl.project.description }}">
                             <oui-header-tabs class="mt-3">


### PR DESCRIPTION
## Prevent Padding Bottom from not being taken in account in Firefox

Known issue : https://bugzilla.mozilla.org/show_bug.cgi?id=748518

MANAGER-2641