### PR TITLE
refactor: remove unused ng-ovh-doc-url dependency

### DIFF
--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -20,7 +20,6 @@
     "@ovh-ux/ng-ovh-apiv7": "^2.0.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.0-alpha.1",
     "@ovh-ux/ng-ovh-contacts": "^1.0.1",
-    "@ovh-ux/ng-ovh-doc-url": "^1.0.0",
     "@ovh-ux/ng-ovh-otrs": "^7.0.1",
     "@ovh-ux/ng-ovh-payment-method": "^2.1.1",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -26,7 +26,6 @@
     "@ovh-ux/ng-ovh-chatbot": "^2.0.1",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.0-alpha.1",
     "@ovh-ux/ng-ovh-contacts": "^1.0.1",
-    "@ovh-ux/ng-ovh-doc-url": "^1.0.0",
     "@ovh-ux/ng-ovh-otrs": "^7.0.1",
     "@ovh-ux/ng-ovh-payment-method": "^2.1.1",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -41,7 +41,6 @@
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.0-alpha.1",
-    "@ovh-ux/ng-ovh-doc-url": "^1.0.0",
     "@ovh-ux/ng-ovh-otrs": "^7.0.0",
     "@ovh-ux/ng-ovh-payment-method": "^2.1.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",

--- a/packages/manager/modules/pci/src/index.js
+++ b/packages/manager/modules/pci/src/index.js
@@ -10,7 +10,6 @@ import '@ovh-ux/ng-ovh-cloud-universe-components';
 import '@ovh-ux/ng-ovh-proxy-request';
 import '@ovh-ux/ng-ovh-user-pref';
 import '@ovh-ux/ng-ovh-swimming-poll';
-import '@ovh-ux/ng-ovh-doc-url';
 import '@ovh-ux/ng-ovh-api-wrappers'; // should be a peer dependency of ovh-api-services
 import 'ovh-api-services';
 import 'ovh-ui-angular';
@@ -66,7 +65,6 @@ angular
     'ngOvhProxyRequest',
     'ngOvhUserPref',
     'ngOvhSwimmingPoll',
-    'ngOvhDocUrl',
     'ngUirouterBreadcrumb',
     'ngUiRouterLayout',
     'ngAtInternet',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,6 +1607,24 @@
     lodash "^4.17.11"
     moment "^2.24.0"
 
+"@ovh-ux/manager-pci@^0.5.0-alpha.0":
+  version "0.5.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-pci/-/manager-pci-0.5.0-alpha.3.tgz#f958221852eade53f529f2399a1f6074686cf839"
+  integrity sha512-1vvd1m34UhsZ30cowBZTvFTKJ4T3NyXfW4Bbg7hD3UmgxHG98Nk6R28hCBU8NC94Foxt+7LdqySd7SgSPOrb5Q==
+  dependencies:
+    "@fortawesome/fontawesome-free" "^5.8.2"
+    "@ovh-ux/manager-config" "^0.2.0"
+    d3 "~3.5.13"
+    file-saver "^2.0.1"
+    flag-icon-css "~0.8.5"
+    ipaddr.js "^1.9.0"
+    jsurl "^0.1.5"
+    lodash "^4.17.11"
+    moment "^2.19"
+    urijs "^1.19.1"
+    validator "^10.11.0"
+    xterm "^3.12.2"
+
 "@ovh-ux/manager-webpack-config@^3.0.7":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@ovh-ux/manager-webpack-config/-/manager-webpack-config-3.0.7.tgz#d158154e22c44a225dd923505c62b8a7e6343c1f"
@@ -1727,14 +1745,6 @@
   integrity sha512-1tApDRCcCp1lBVFojfwc8Uy0Ytaxjubxyh9dCiUtW701J+3c3F724wrzpnovPEB6UoH7blQ9Xr4Zc8Je6CzhUA==
   dependencies:
     animated-scroll-to "^1.2.2"
-
-"@ovh-ux/ng-ovh-doc-url@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-doc-url/-/ng-ovh-doc-url-1.0.0.tgz#4661f1c126f68308501412bc3f7205d6fd0f0a63"
-  integrity sha512-NA4OBiE/T9AvoCPXDQ54VsMLP7eIc6Qesj9JsR03vBHaHVIKvUf7mpEzyRUprVYX8hIxMRuC/Ngfh3tt+vXcNw==
-  dependencies:
-    lodash "~4.17.11"
-    urijs "^1.19.1"
 
 "@ovh-ux/ng-ovh-http@^4.0.1-beta.0":
   version "4.0.1-beta.0"


### PR DESCRIPTION
# remove unused dependency

Since #521 remove the entire legacy part, this following dependency could
be removed.

It contains:

Component:
- ovhDocUrl

Provider
- ovhDocUrl

### :nail_care: Refactor

ad6f79e - refactor: remove unused ng-ovh-doc-url dependency

### :house: Internal

- No QC required.

ref: #521