### PR TITLE
fix(pci.project.ssh-keys.add): associate labels with form element

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/add.html
@@ -9,10 +9,10 @@
         data-on-dismiss="$ctrl.goBack()"
         data-loading="$ctrl.isLoading">
         <oui-field label="{{ ::'pci_projects_project_sshKeys_add_name' | translate }}" size="xl">
-            <input class="oui-input" type="text" name="name" ng-model="$ctrl.name" required>
+            <input class="oui-input" type="text" id="name" name="name" ng-model="$ctrl.name" required>
         </oui-field>
         <oui-field label="{{ ::'pci_projects_project_sshKeys_add_key' | translate }}" size="xl">
-            <oui-textarea model="$ctrl.publicKey" name="key" placeholder="{{ ::'pci_projects_project_sshKeys_add_key_description' | translate }}" rows="5" required></oui-textarea>
+            <oui-textarea model="$ctrl.publicKey" id="key" name="key" placeholder="{{ ::'pci_projects_project_sshKeys_add_key_description' | translate }}" rows="5" required></oui-textarea>
         </oui-field>
     </oui-modal>
 </form>


### PR DESCRIPTION
# Associate labels with form element

### :bug: Bug Fix

068c76d - fix(pci.project.ssh-keys.add): associate labels with form element

### :house: Internal

- No QC required.

ref: https://github.com/ovh-ux/ovh-ui-angular/blob/v3.0.2/packages/oui-field/src/field.controller.js#L66