### PR TITLE
fix(pci.project.vouchers.add): associate label with input element

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/vouchers/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/vouchers/add/add.html
@@ -10,6 +10,7 @@
     <oui-field data-label="{{ ::'cpb_vouchers_your_voucher' | translate }}">
         <input type="text"
             class="oui-input"
+            id="voucherAddValue"
             name="voucherAddValue"
             data-ng-model="$ctrl.model.value"
             required />


### PR DESCRIPTION
# Associate label with input element

### :bug: Bug Fix

154af0c  - fix(pci.project.vouchers.add): associate label with input element

### :house: Internal

- No QC required.

ref: https://github.com/ovh-ux/ovh-ui-angular/blob/v3.0.2/packages/oui-field/src/field.controller.js#L66