### PR TITLE
fix(pci.container.object.add): associate label with input element

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/object/add/add.html
@@ -10,7 +10,7 @@
         data-loading="$ctrl.isLoading">
 
         <oui-field data-label="{{:: 'pci_projects_project_storages_containers_container_object_add_prefix_label' | translate }}" data-size="xl">
-            <input class="oui-input" type="text" id="lastname" name="prefix" data-ng-model="$ctrl.prefix" required minlength="3" maxlength="32">
+            <input class="oui-input" type="text" id="prefix" name="prefix" data-ng-model="$ctrl.prefix" required minlength="3" maxlength="32">
         </oui-field>
 
         <oui-field data-label="{{:: 'pci_projects_project_storages_containers_container_object_add_files_label' | translate }}" data-size="xl">


### PR DESCRIPTION
# Associate label with input element

### :bug: Bug Fix

c41dc64 - fix(pci.container.object.add): associate label with input element

### :house: Internal

- No QC required.

ref: https://github.com/ovh-ux/ovh-ui-angular/blob/v3.0.2/packages/oui-field/src/field.controller.js#L66