### PR TITLE
fix(ng-uirouter-breadcrumb): disable last breadcrumb link

### DIFF
--- a/packages/components/ng-uirouter-breadcrumb/src/ng-uirouter-breadcrumb.html
+++ b/packages/components/ng-uirouter-breadcrumb/src/ng-uirouter-breadcrumb.html
@@ -1,6 +1,6 @@
 <ul>
     <li data-ng-repeat="element in $ctrl.breadcrumb track by element.url">
-        <a data-ng-if="element.url && !element.active" data-ng-href="{{ element.url }}" data-ng-bind="element.name"></a>
-        <span data-ng-if="!(element.url && !element.active)" data-ng-bind="element.name"></span>
+        <a data-ng-if="element.url && !element.active && !$last" data-ng-href="{{ element.url }}" data-ng-bind="element.name"></a>
+        <span data-ng-if="!(element.url && !element.active && !$last)" data-ng-bind="element.name"></span>
     </li>
 </ul>


### PR DESCRIPTION
## fix(ng-uirouter-breadcrumb): disable last breadcrumb link

### Description of the Change

ca461544 — fix(ng-uirouter-breadcrumb): disable last breadcrumb link
