### PR TITLE
fix(pci.private-networks.delete): keep loading on deletion

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/private-networks/delete/delete.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/delete/delete.controller.js
@@ -46,9 +46,6 @@ export default class {
           }),
           'error',
         );
-      })
-      .finally(() => {
-        this.isLoading = false;
       });
   }
 }


### PR DESCRIPTION
Avoid modal content from appearing during state transition

MANAGER-2655