### PR TITLE
fix(ng-uirouter-lin-progress): avoid nprogress on ignored transition

### DIFF
--- a/packages/components/ng-uirouter-line-progress/src/ng-uirouter-line-progress.config.js
+++ b/packages/components/ng-uirouter-line-progress/src/ng-uirouter-line-progress.config.js
@@ -1,8 +1,10 @@
 import NProgress from 'nprogress';
 
 export default /* @ngInject */ ($transitions) => {
-  $transitions.onBefore({}, () => {
-    NProgress.start();
+  $transitions.onBefore({}, (transition) => {
+    if (!transition.ignored()) {
+      NProgress.start();
+    }
   });
 
   $transitions.onFinish({}, () => {


### PR DESCRIPTION
## fix(ng-uirouter-lin-progress): avoid nprogress on ignored transition

### Description of the Change

ad7af905 — fix(ng-uirouter-lin-progress): avoid nprogress on ignored transition
