### PR TITLE
build: upgrade ovh-api-service to v6.18.1

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -34,7 +34,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.17.1",
+    "ovh-api-services": "^6.18.1",
     "ovh-ui-angular": "^3.1.0",
     "ovh-ui-kit": "^2.32.0",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/apps/layout-ovh/package.json
+++ b/packages/manager/apps/layout-ovh/package.json
@@ -73,7 +73,7 @@
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.17.1",
+    "ovh-api-services": "^6.18.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.1.0",

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -40,7 +40,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
-    "ovh-api-services": "^6.17.1",
+    "ovh-api-services": "^6.18.1",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.1.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -55,7 +55,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
-    "ovh-api-services": "^6.17.1",
+    "ovh-api-services": "^6.18.1",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.1.0",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -31,7 +31,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.17.1"
+    "ovh-api-services": "^6.18.1"
   },
   "devDependencies": {
     "@ovh-ux/manager-webpack-config": "^3.0.7",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -24,7 +24,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.17.1",
+    "ovh-api-services": "^6.18.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.1.0",
     "ovh-ui-kit": "^2.32.0",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -31,7 +31,7 @@
     "lodash": "^3.10.1",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.17.1",
+    "ovh-api-services": "^6.18.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.1.0",
     "ovh-ui-kit": "^2.32.0"

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -48,7 +48,7 @@
     "angular-translate": "^2.11.0",
     "angular-ui-bootstrap": "~1.3.3",
     "d3": "~3.5.13",
-    "ovh-api-services": "^6.8.0",
+    "ovh-api-services": "^6.18.1",
     "ovh-ui-angular": "^2.29.0"
   }
 }

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -45,7 +45,7 @@
     "angular-sanitize": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-translate-loader-pluggable": "^1.3.1",
-    "ovh-api-services": "^6.8.0",
+    "ovh-api-services": "^6.18.1",
     "ovh-ui-angular": "^2.29.0"
   }
 }

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -40,7 +40,7 @@
     "angular-translate": "^2.18.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.8.0",
+    "ovh-api-services": "^6.18.1",
     "ovh-ui-angular": "^2.29.0",
     "ovh-ui-kit": "^2.29.0",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -35,7 +35,7 @@
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
     "bootstrap-tour": "^0.12.0",
-    "ovh-api-services": "^6.8.0",
+    "ovh-api-services": "^6.18.1",
     "ovh-ui-angular": "^2.29.0",
     "ovh-ui-kit": "^2.29.0"
   },

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -61,7 +61,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
-    "ovh-api-services": "^6.12.0",
+    "ovh-api-services": "^6.18.1",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-angular": "^2.29.0",

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -31,7 +31,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^6.18.0"
+    "ovh-api-services": "^6.18.1"
   },
   "dependencies": {
     "@ovh-ux/ng-ovh-sidebar-menu": "^8.0.1",

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -55,7 +55,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.8.0",
+    "ovh-api-services": "^6.18.1",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.29.0",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -38,7 +38,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.8.0",
+    "ovh-api-services": "^6.18.1",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-angular": "^2.29.0",
     "ovh-ui-kit": "^2.29.0",

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -49,7 +49,7 @@
     "angular-ui-bootstrap": "~1.3.3",
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.8.0",
+    "ovh-api-services": "^6.18.1",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-kit": "^2.29.0",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9180,10 +9180,10 @@ ovh-angular-ui-confirm-modal@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-angular-ui-confirm-modal/-/ovh-angular-ui-confirm-modal-1.0.2.tgz#92e6736588a4fb1de6353f1a17ab1962679a698d"
   integrity sha512-3V17DbzWjUjl9sKCd25Oycn+7eqg6iW+DpizwVmixHFzDNDMnpKSGmxRLrOq+q9YNE7IepoAKWjoSiy2+zOEEg==
 
-ovh-api-services@^6.17.1:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.18.0.tgz#f039a0db77343d828b8ce0293df037949fca3b28"
-  integrity sha512-G6n4hdge4BY73xa4BINXIpgJ55PINu+LfFgAWMsSaO0zfA3KrIj0FvpFXKjlh/a4WOKBE4RQZD6SmLYUila2ug==
+ovh-api-services@^6.18.1:
+  version "6.18.1"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.18.1.tgz#be08dafa5e8438ada21bc5999d10d4e884a5f808"
+  integrity sha512-aEnsKl+7eCPsvvRS076icjz4t250IFHstH49W+ZxXR93NoAX4yDlLWaFJtFWKR+XVSEJ29WosiHdUh/r/WH+rg==
   dependencies:
     lodash "^3.10.1"
 


### PR DESCRIPTION
# Upgrade ovh-api-service to v6.18.1

### :arrow_up: Upgrade

437a000 - build: upgrade ovh-api-service to v6.18.1

### :house: Internal

- No QC required.

ref: https://github.com/ovh-ux/ovh-api-services/pull/166