### PR TITLE
fix(apps.layout-ovh): upgrade manager-navbar to v0.4.2

### DIFF
--- a/packages/manager/apps/layout-ovh/package.json
+++ b/packages/manager/apps/layout-ovh/package.json
@@ -16,7 +16,7 @@
     "@ovh-ux/manager-config": "^0.2.0",
     "@ovh-ux/manager-core": "^5.2.1",
     "@ovh-ux/manager-freefax": "^5.1.2",
-    "@ovh-ux/manager-navbar": "^0.3.0-alpha.0",
+    "@ovh-ux/manager-navbar": "^0.4.2",
     "@ovh-ux/manager-overthebox": "^4.2.2",
     "@ovh-ux/manager-sms": "^6.2.1",
     "@ovh-ux/manager-telecom-styles": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,13 +1655,23 @@
     rollup-pluginutils "^2.3.3"
     slash "^2.0.0"
 
-"@ovh-ux/manager-navbar@^0.3.0-alpha.0":
-  version "0.3.3"
-  resolved "https://nexus.ovh.net/nexus3/repository/npm-all/@ovh-ux/manager-navbar/-/manager-navbar-0.3.3.tgz#0c1badc7001e571ee378e5bcb35632907aeb4225"
-  integrity sha512-aLRbFUuy5m6T009wEUqA6sXmNOL3+yRBK7gxlEfQw3PGUe5sPOnOXJiISnRinm9+Ned+LLjVxKFSdBd+q/diBA==
+"@ovh-ux/manager-pci@^0.12.0":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-pci/-/manager-pci-0.12.3.tgz#c28a95be238ced10c0f52dd406c73b183732bdaf"
+  integrity sha512-wKu9JBW0NzfCgIvbgIxBLu3ETHcqT4Ddm2sPN+cS4D4iM018MLHj9RFrEFISkipxnTA5o2194+7eNJk9ZGadnQ==
   dependencies:
+    "@fortawesome/fontawesome-free" "^5.8.2"
+    "@ovh-ux/manager-config" "^0.2.0"
+    d3 "~3.5.13"
+    file-saver "^2.0.1"
+    flag-icon-css "~0.8.5"
+    ipaddr.js "^1.9.0"
+    jsurl "^0.1.5"
     lodash "^4.17.11"
-    moment "^2.24.0"
+    moment "^2.19"
+    urijs "^1.19.1"
+    validator "^10.11.0"
+    xterm "^3.12.2"
 
 "@ovh-ux/manager-webpack-config@^3.0.7":
   version "3.0.7"


### PR DESCRIPTION
# Upgrade manager-navbar to v0.4.2

### :arrow_up: Upgrade

2053616 - fix(apps.layout-ovh): upgrade manager-navbar to v0.4.2

### :house: Internal

- No QC required.

fix #690