### PR TITLE
fix(apps.layout-ovh): upgrade manager-navbar to v0.5.0

### DIFF
--- a/packages/manager/apps/layout-ovh/package.json
+++ b/packages/manager/apps/layout-ovh/package.json
@@ -16,7 +16,7 @@
     "@ovh-ux/manager-config": "^0.2.0",
     "@ovh-ux/manager-core": "^5.2.5",
     "@ovh-ux/manager-freefax": "^5.1.2",
-    "@ovh-ux/manager-navbar": "^0.4.2",
+    "@ovh-ux/manager-navbar": "^0.5.0",
     "@ovh-ux/manager-overthebox": "^4.2.2",
     "@ovh-ux/manager-sms": "^6.2.1",
     "@ovh-ux/manager-telecom-styles": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,14 +1655,6 @@
     rollup-pluginutils "^2.3.3"
     slash "^2.0.0"
 
-"@ovh-ux/manager-navbar@^0.4.2", "@ovh-ux/manager-navbar@^0.4.4":
-  version "0.4.4"
-  resolved "https://nexus.ovh.net/nexus3/repository/npm-all/@ovh-ux/manager-navbar/-/manager-navbar-0.4.4.tgz#67c6cdeb0ec48aa104e9bdd9afbe7c166569e6d7"
-  integrity sha512-fbEWJzkM+yZcbygdcYgqpS40/ghrp618GihzNYglpCerowYLtlqLcZxja0BvP5uV6TqXD35Oq6faqoOlDuwUgg==
-  dependencies:
-    lodash "^4.17.11"
-    moment "^2.24.0"
-
 "@ovh-ux/manager-pci@^0.12.0":
   version "0.12.3"
   resolved "https://registry.yarnpkg.com/@ovh-ux/manager-pci/-/manager-pci-0.12.3.tgz#c28a95be238ced10c0f52dd406c73b183732bdaf"


### PR DESCRIPTION
Upgrade manager-navbar to v0.5.0

### :bug: Bug Fix

3b244f4 - fix(apps.layout-ovh): upgrade manager-navbar to v0.5.0

### :house: Internal

- No QC required.

fix #775