### PR TITLE
fix(pci.projects.failover-ips-edit): refresh list after edit

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ip/edit/edit.component.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ip/edit/edit.component.js
@@ -1,0 +1,12 @@
+import controller from './edit.controller';
+import template from './edit.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    projectId: '<',
+    serviceName: '<',
+    ip: '<',
+  },
+};

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ip/edit/edit.module.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ip/edit/edit.module.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import 'angular-translate';
 import '@uirouter/angularjs';
 
+import component from './edit.component';
 import routing from './edit.routing';
 
 const moduleName = 'ovhManagerPciProjectFailoverIpEdit';
@@ -11,6 +12,7 @@ angular
     'ui.router',
     'pascalprecht.translate',
   ])
-  .config(routing);
+  .config(routing)
+  .component('pciProjectFailoverIpsEdit', component);
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ip/edit/edit.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/failover-ip/edit/edit.routing.js
@@ -1,5 +1,4 @@
-import controller from './edit.controller';
-import template from './edit.html';
+import find from 'lodash/find';
 
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider
@@ -7,9 +6,7 @@ export default /* @ngInject */ ($stateProvider) => {
       url: '/:serviceName/edit',
       views: {
         modal: {
-          controller,
-          controllerAs: '$ctrl',
-          template,
+          component: 'pciProjectFailoverIpsEdit',
         },
       },
       layout: 'modal',
@@ -19,6 +16,10 @@ export default /* @ngInject */ ($stateProvider) => {
       },
       resolve: {
         breadcrumb: () => null,
+        serviceName: /* @ngInject */ $transition$ => $transition$.params().serviceName,
+        ip: /* @ngInject */ (serviceName, failoverIps) => find(failoverIps, {
+          id: serviceName,
+        }),
       },
     });
 };


### PR DESCRIPTION
See : MANAGER-2481

**issue** : when changing associated instance to ip failover, the instance is not refreshed in the list of failover ips

**fix** : after instance is successfully associated, the ip object is mutated and updated with the new instance (and so the list is updated because the ip comes from the ipfo list, see resolve in edit routing)