### PR TITLE
Add some examples for ng-uirouter-* components

### DIFF
--- a/packages/components/ng-uirouter-breadcrumb/examples/index.html
+++ b/packages/components/ng-uirouter-breadcrumb/examples/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>@ovh-ux/ng-uirouter-breadcrumb</title>
+    </head>
+    <body ng-app="myApp">
+        <nav>
+            <a ui-sref="foo">Foo</a>
+            <a ui-sref="foo.bar">Bar</a>
+            <a ui-sref="foo.bar.baz">Baz</a>
+        </nav>
+        <uirouter-breadcrumb></uirouter-breadcrumb>
+        <ui-view></ui-view>
+        <script src="https://unpkg.com/angular@latest/angular.js"></script>
+        <script src="https://unpkg.com/@uirouter/angularjs@latest/release/angular-ui-router.js"></script>
+        <script src="https://unpkg.com/@ovh-ux/ng-uirouter-breadcrumb@latest"></script>
+        <script>
+            var myApp = angular
+                .module('myApp', ['ui.router', 'ngUirouterBreadcrumb'])
+                .config(function ($stateProvider) {
+                    $stateProvider.state('foo', {
+                        url: '/foo',
+                        template: '<h2>Foo</h2>',
+                        resolve: {
+                            breadcrumb: function () {
+                                return 'foo';
+                            }
+                        }
+                    });
+                    $stateProvider.state('foo.bar', {
+                        url: '/bar',
+                        template: '<h2>Bar</h2>',
+                        resolve: {
+                            breadcrumb: function () {
+                                return 'bar';
+                            }
+                        }
+                    });
+                    $stateProvider.state('foo.bar.baz', {
+                        url: '/baz',
+                        template: '<h2>Baz</h2>',
+                        resolve: {
+                            breadcrumb: function () {
+                                return 'baz';
+                            }
+                        }
+                    });
+                });
+        </script>
+    </body>
+</html>

--- a/packages/components/ng-uirouter-layout/examples/index.html
+++ b/packages/components/ng-uirouter-layout/examples/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>@ovh-ux/ng-uirouter-layout</title>
+        <link rel="stylesheet" href="https://unpkg.com/bootstrap@3.4.1/dist/css/bootstrap.min.css">
+    </head>
+    <body ng-app="myApp">
+        <nav>
+            <a ui-sref="foo">Foo</a>
+        </nav>
+        <script src="https://unpkg.com/angular@latest/angular.js"></script>
+        <script src="https://unpkg.com/@uirouter/angularjs@latest/release/angular-ui-router.js"></script>
+        <script src="https://unpkg.com/@ovh-ux/ng-uirouter-layout@latest"></script>
+        <script src="https://unpkg.com/jquery@1.12.4/dist/jquery.js"></script>
+        <script src="https://unpkg.com/bootstrap@3.4.1/dist/js/bootstrap.min.js"></script>
+        <script src="https://unpkg.com/angular-ui-bootstrap@1.3.3/dist/ui-bootstrap-tpls.js"></script>
+        <script>
+            var myApp = angular
+                .module('myApp', ['ui.router', 'ui.bootstrap', 'ngUiRouterLayout'])
+                .config(function ($stateProvider) {
+                    $stateProvider.state('foo', {
+                        url: '/foo',
+                        template: '<h2>Foo</h2>',
+                        layout: 'modal'
+                    });
+                });
+        </script>
+    </body>
+</html>

--- a/packages/components/ng-uirouter-line-progress/examples/index.html
+++ b/packages/components/ng-uirouter-line-progress/examples/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>@ovh-ux/ng-uirouter-line-progress</title>
+    </head>
+    <body ng-app="myApp">
+        <nav>
+            <a ui-sref="foo">Foo</a>
+            <a ui-sref="bar">Bar</a>
+            <a ui-sref="baz">Baz</a>
+        </nav>
+        <ui-view></ui-view>
+        <script src="https://unpkg.com/angular@latest/angular.js"></script>
+        <script src="https://unpkg.com/@uirouter/angularjs@latest/release/angular-ui-router.js"></script>
+        <script src="https://unpkg.com/@ovh-ux/ng-uirouter-line-progress@latest"></script>
+        <script>
+            var myApp = angular
+                .module('myApp', ['ui.router', 'ngUirouterLineProgress'])
+                .config(function ($stateProvider) {
+                    $stateProvider.state('foo', {
+                        url: '/foo',
+                        template: '<h2>Foo</h2>'
+                    });
+                    $stateProvider.state('bar', {
+                        url: '/bar',
+                        template: '<h2>Bar</h2>'
+                    });
+                    $stateProvider.state('baz', {
+                        url: '/baz',
+                        template: '<h2>Baz</h2>'
+                    });
+                });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
# Add some examples for ng-uirouter-* components

I'm using unpkg.com to provide usage example. If that make sense I can refer this example into the README.md file.

### :memo: Documentation

ed59a5d - docs(components.ng-uirouter-breadcrumb): add example
7b6e8f0 - docs(components.ng-uirouter-layout): add example
985bf79 - docs(components.ng-uirouter-line-progress): add example
