### PR TITLE
docs(server.sidebar.readme): set the right badge url

### DIFF
--- a/packages/manager/modules/server-sidebar/README.md
+++ b/packages/manager/modules/server-sidebar/README.md
@@ -1,6 +1,6 @@
 # manager-server-sidebar
 
-[![npm version](https://badgen.net/npm/v/@ovh-ux/manager-server-sidebar)](https://www.npmjs.com/package/@ovh-ux/manager-server-sidebar) [![Downloads](https://badgen.net/npm/dt/@ovh-ux/manager-server-sidebar)](https://npmjs.com/package/@ovh-ux/manager-server-sidebar) [![Dependencies](https://badgen.net/david/dep/ovh-ux/manager/packages/manager/modules/sidebar)](https://npmjs.com/package/@ovh-ux/manager-server-sidebar?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh-ux/manager/packages/manager/modules/sidebar)](https://npmjs.com/package/@ovh-ux/manager-server-sidebar?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
+[![npm version](https://badgen.net/npm/v/@ovh-ux/manager-server-sidebar)](https://www.npmjs.com/package/@ovh-ux/manager-server-sidebar) [![Downloads](https://badgen.net/npm/dt/@ovh-ux/manager-server-sidebar)](https://npmjs.com/package/@ovh-ux/manager-server-sidebar) [![Dependencies](https://badgen.net/david/dep/ovh-ux/manager/packages/manager/modules/server-sidebar)](https://npmjs.com/package/@ovh-ux/manager-server-sidebar?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh-ux/manager/packages/manager/modules/server-sidebar)](https://npmjs.com/package/@ovh-ux/manager-server-sidebar?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
 
 ## Install
 


### PR DESCRIPTION
# Set the right badge URL

Package were previously named `sidebar` and it has been updated to `server-sidebar`.

### :memo: Documentation

4475308 - docs(server.sidebar.readme): set the right badge url