### PR TITLE
build: upgrade ng-ovh-sidebar-menu to v8.3.0

### DIFF
--- a/packages/manager/apps/layout-ovh/package.json
+++ b/packages/manager/apps/layout-ovh/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
     "@ovh-ux/ng-ovh-otrs": "^7.0.1",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",
-    "@ovh-ux/ng-ovh-sidebar-menu": "^8.1.0",
+    "@ovh-ux/ng-ovh-sidebar-menu": "^8.3.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.0.0-beta.0",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-config": "^0.2.0",
     "@ovh-ux/manager-core": "^5.2.5",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.0-alpha.4",
-    "@ovh-ux/ng-ovh-sidebar-menu": "^8.1.0",
+    "@ovh-ux/ng-ovh-sidebar-menu": "^8.3.0",
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,10 +1830,10 @@
     "@ovh-ux/translate-async-loader" "^1.0.0"
     jquery "^2.1.3"
 
-"@ovh-ux/ng-ovh-sidebar-menu@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-sidebar-menu/-/ng-ovh-sidebar-menu-8.1.0.tgz#11eb4f6461f4faaa83aef5fcec756f9a1268cf62"
-  integrity sha512-+htSYv5PkfTo4qiBp+Cz7gFgXXt4lKzAQKNO0LJtj2cnwI+/E27GHy+zjkFN75q6qI509XGvvqvUqx0kYp2anA==
+"@ovh-ux/ng-ovh-sidebar-menu@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-sidebar-menu/-/ng-ovh-sidebar-menu-8.3.0.tgz#3a7a16cd30e251793b4846df1daf50ea1af5360a"
+  integrity sha512-HSiggjrK6IGoWI7SoZIObzNTQqxHOD5AubrB1cPFafUxrL4zOVVPHmfW/YbT0d5mYn31+kRzINS8tUgXHtBUgw==
 
 "@ovh-ux/ng-ovh-sso-auth@^4.0.0", "@ovh-ux/ng-ovh-sso-auth@^4.0.0-beta.0":
   version "4.0.0"


### PR DESCRIPTION
# Upgrade ng-ovh-sidebar-menu to v8.3.0

### :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- @ovh-ux/ng-ovh-sidebar-menu@8.3.0

### :house: Internal

- No QC required.

/cc @lizardK 