### PR TITLE
docs(telecom.dashboard): set to the right module path for badges

### DIFF
--- a/packages/manager/modules/telecom-dashboard/README.md
+++ b/packages/manager/modules/telecom-dashboard/README.md
@@ -1,6 +1,6 @@
 # telecom-dashboard
 
-[![npm version](https://badgen.net/npm/v/@ovh-ux/manager-telecom-dashboard)](https://www.npmjs.com/package/@ovh-ux/manager-telecom-dashboard) [![Downloads](https://badgen.net/npm/dt/@ovh-ux/manager-telecom-dashboard)](https://npmjs.com/package/@ovh-ux/manager-telecom-dashboard) [![Dependencies](https://badgen.net/david/dep/ovh-ux/manager/packages/manager/modules/sms)](https://npmjs.com/package/@ovh-ux/manager-telecom-dashboard?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh-ux/manager/packages/manager/modules/sms)](https://npmjs.com/package/@ovh-ux/manager-telecom-dashboard?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
+[![npm version](https://badgen.net/npm/v/@ovh-ux/manager-telecom-dashboard)](https://www.npmjs.com/package/@ovh-ux/manager-telecom-dashboard) [![Downloads](https://badgen.net/npm/dt/@ovh-ux/manager-telecom-dashboard)](https://npmjs.com/package/@ovh-ux/manager-telecom-dashboard) [![Dependencies](https://badgen.net/david/dep/ovh-ux/manager/packages/manager/modules/telecom-dashboard)](https://npmjs.com/package/@ovh-ux/manager-telecom-dashboard?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh-ux/manager/packages/manager/modules/telecom-dashboard)](https://npmjs.com/package/@ovh-ux/manager-telecom-dashboard?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
 
 ## Install
 


### PR DESCRIPTION
# Set to the right module path for badges

### :memo: Documentation

55695b0 - docs(telecom.dashboard): set to the right module path for badges