### PR TITLE
build(deps): upgrade ovh-api-service to v6.31.0

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -34,7 +34,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-ui-angular": "^3.2.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/apps/layout-ovh/package.json
+++ b/packages/manager/apps/layout-ovh/package.json
@@ -74,7 +74,7 @@
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.2.2",

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -40,7 +40,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.2.2",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -55,7 +55,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
-    "ovh-api-services": "^6.28.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.2.2",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -31,7 +31,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.26.0"
+    "ovh-api-services": "^6.31.0"
   },
   "devDependencies": {
     "@ovh-ux/manager-webpack-config": "^3.0.8",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -24,7 +24,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.2.2",
     "ovh-ui-kit": "^2.33.3",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -31,7 +31,7 @@
     "lodash": "^3.10.1",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.2.2",
     "ovh-ui-kit": "^2.33.3"

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -52,7 +52,7 @@
     "angular-translate": "^2.11.0",
     "angular-ui-bootstrap": "~1.3.3",
     "d3": "~3.5.13",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-ui-angular": "^3.2.2"
   }
 }

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -48,7 +48,7 @@
     "angular-sanitize": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-translate-loader-pluggable": "^1.3.1",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-ui-angular": "^3.2.2"
   }
 }

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -44,7 +44,7 @@
     "angular-translate": "^2.18.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-ui-angular": "^3.2.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -46,7 +46,7 @@
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
     "bootstrap-tour": "^0.12.0",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-ui-angular": "^3.2.2",
     "ovh-ui-kit": "^2.33.3"
   }

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -65,7 +65,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",
-    "ovh-api-services": "^6.28.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-angular": "^3.2.2",

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -43,6 +43,6 @@
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^6.26.0"
+    "ovh-api-services": "^6.31.0"
   }
 }

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -59,7 +59,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-checkbox-table": "^0.1.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -42,7 +42,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-angular": "^3.2.2",
     "ovh-ui-kit": "^2.33.3",

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -53,7 +53,7 @@
     "angular-ui-bootstrap": "~1.3.3",
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^6.26.0",
+    "ovh-api-services": "^6.31.0",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9225,17 +9225,10 @@ ovh-angular-ui-confirm-modal@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-angular-ui-confirm-modal/-/ovh-angular-ui-confirm-modal-1.0.2.tgz#92e6736588a4fb1de6353f1a17ab1962679a698d"
   integrity sha512-3V17DbzWjUjl9sKCd25Oycn+7eqg6iW+DpizwVmixHFzDNDMnpKSGmxRLrOq+q9YNE7IepoAKWjoSiy2+zOEEg==
 
-ovh-api-services@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.26.0.tgz#6c4882f56a5a21da9d3f58a108c98ac8958480c5"
-  integrity sha512-wInhjMJkLQtIw6CwlFXQ0Sz8Oak4Vu52yoxlZomPNsA2Ions57pHkYIE4nXyvvKr9cZUO6lf70/ZeKk25u+PBQ==
-  dependencies:
-    lodash "^3.10.1"
-
-ovh-api-services@^6.28.0:
-  version "6.30.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.30.0.tgz#d02a5eda1878911077721a3677d1ba598d572f4c"
-  integrity sha512-JmtAkRQTE8Ky5h6Y50YTHjH4AUt7omEkeEBoNk6G+ytHuJhjHFfUgR2JsRt2V1W7OcZrHjRWC6yDrrFU6LYU3g==
+ovh-api-services@^6.31.0:
+  version "6.31.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.31.0.tgz#c010b73f9546be4eee8619a5026c08e8186bd834"
+  integrity sha512-GmDvDDlVhDgpe8I1/q6awP0C4qulWOPNpfz1tsrmMoaw3cnHVOJxLZc71gVxbosmeRQGonwYSIrhI/fKoD7cTA==
   dependencies:
     lodash "^3.10.1"
 


### PR DESCRIPTION
# Upgrade ovh-api-service to v6.31.0

## :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- ovh-api-services@6.31.0

## :house: Internal

- No QC required.

/cc @Jisay 