### PR TITLE
fix(pci.projects.storages): improve performance of containers list

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/containers/containers.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/containers.service.js
@@ -116,9 +116,10 @@ export default class PciStoragesContainersService {
       });
   }
 
-  getAll(projectId, isArchive = null) {
+  getAll(projectId, isArchive = null, withObjects = false) {
     const queryParams = {
       serviceName: projectId,
+      withObjects,
     };
 
     if (isArchive === true) {


### PR DESCRIPTION
See : DTRUN-1924, MANAGER-2943

issue : containers list crashing for huge list of containers
fix : fetch containers without the list of objects to improve performance