### PR TITLE
build: update manager-pci to v0.20.0

### DIFF
--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -14,7 +14,7 @@
     "@ovh-ux/manager-cloud-styles": "^0.3.0-alpha.1",
     "@ovh-ux/manager-config": "^0.2.0",
     "@ovh-ux/manager-core": "^5.3.0",
-    "@ovh-ux/manager-pci": "^0.19.0",
+    "@ovh-ux/manager-pci": "^0.20.0",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-apiv7": "^2.0.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -17,7 +17,7 @@
     "@ovh-ux/manager-config": "^0.2.0",
     "@ovh-ux/manager-core": "^6.0.1",
     "@ovh-ux/manager-navbar": "^1.0.1",
-    "@ovh-ux/manager-pci": "^0.19.0",
+    "@ovh-ux/manager-pci": "^0.20.0",
     "@ovh-ux/manager-telecom-styles": "^3.0.0",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",


### PR DESCRIPTION
# Update manager-pci to v0.20.0

Both applications `public-cloud` and `pci` now refer to the latest version
of @ovh-ux/manager-pci module.

## :arrow_up: Upgrade

47e3863 - build: update manager-pci to v0.20.0

## :house: Internal

- No QC required.