### PR TITLE
fix(pci.instances): do not display reverse if not found

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/instances.service.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instances.service.js
@@ -522,7 +522,8 @@ export default class PciProjectInstanceService {
       return this.OvhApiIp.Reverse().v6().query({ ip }).$promise
         .then(([ipReverse]) => (ipReverse
           ? this.OvhApiIp.Reverse().v6().get({ ip, ipReverse }).$promise
-          : null));
+          : null))
+        .catch(error => (error.status === 404 ? null : Promise.reject(error)));
     }
     return null;
   }


### PR DESCRIPTION
If NIC is billing NIC, he/she will not be able to get IPs