### PR TITLE
build: set manually version 1.0.0 to the sign-up module

### DIFF
--- a/packages/manager/apps/sign-up/package.json
+++ b/packages/manager/apps/sign-up/package.json
@@ -16,7 +16,7 @@
     "@ovh-ux/manager-core": "^6.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.1.0",
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
-    "@ovh-ux/sign-up": "^0.0.0",
+    "@ovh-ux/sign-up": "^1.0.0",
     "@uirouter/angularjs": "^1.0.20",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/sign-up/package.json
+++ b/packages/manager/modules/sign-up/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovh-ux/sign-up",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "BSD-3-Clause",
   "files": [


### PR DESCRIPTION
# Set manually version `1.0.0` to the sign-up module

Running `yarn install` based on the latest commit from the `master` branch (7dbf58076d264d9c702617ed67479a1fc02ed4b6) reports the following error:

```sh
$ yarn
yarn install v1.16.0
[1/5] Validating package.json...
[2/5] Resolving packages...
error Couldn't find package "@ovh-ux/sign-up@^0.0.0" required by "@ovh-ux/sign-up-app@1.1.0" on the "npm" registry.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

In fact the module `"@ovh-ux/sign-up"` is defined as a private one so there is no reason that yarn have to do a request to the npm registry.

By setting manually the version to `1.0.0` for the `"@ovh-ux/sign-up"` module and refer to it on the dedicated application `"@ovh-ux/sign-up-app"`, the installation works properly.

## :gear: Build

6293f9e - build: set manually version 1.0.0 to the sign-up module

## :house: Internal

- No QC required.