### PR TITLE
fix(kube-create): fix for polling

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.controller.js
@@ -63,6 +63,7 @@ export default class {
       {},
       {
         method: 'get',
+        retryMaxAttempts: 6,
         successRule: {
           status: READY_STATUS,
         },


### PR DESCRIPTION
## Increase service polling re attempts


### Description of the Change

Increase max re attempts while polling retries at Kubernetes cluster creation

### Applicable Issues

resolves MBP-483