### PR TITLE
build: upgrade manager-pci to v0.24.0 for both pci & public-cloud apps

### DIFF
--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -14,7 +14,7 @@
     "@ovh-ux/manager-cloud-styles": "^0.3.0",
     "@ovh-ux/manager-config": "^0.3.0",
     "@ovh-ux/manager-core": "^6.1.0",
-    "@ovh-ux/manager-pci": "^0.23.0",
+    "@ovh-ux/manager-pci": "^0.24.0",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-apiv7": "^2.0.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -17,7 +17,7 @@
     "@ovh-ux/manager-config": "^0.3.0",
     "@ovh-ux/manager-core": "^6.1.0",
     "@ovh-ux/manager-navbar": "^1.2.0",
-    "@ovh-ux/manager-pci": "^0.23.1",
+    "@ovh-ux/manager-pci": "^0.24.0",
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",


### PR DESCRIPTION
# Upgrade manager-pci to v0.24.0 for both pci & public-cloud apps

## :arrow_up: Upgrade

eb55530 - upgrade manager-pci to v0.24.0 for both pci & public-cloud apps

## :house: Internal

- No QC required.