### PR TITLE
fix: bump lodash to version >= 4.17.14

### DIFF
--- a/packages/components/ng-uirouter-layout/package.json
+++ b/packages/components/ng-uirouter-layout/package.json
@@ -35,7 +35,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-uirouter-layout' --include-filtered-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^5.1.0"

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -28,7 +28,7 @@
     "angular-sanitize": "^1.7.5",
     "angularjs-scroll-glue": "^2.2.0",
     "jquery": "^2.1.3",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.14",
     "oclazyload": "^1.1.0",
     "ovh-angular-responsive-tabs": "^4.0.0"
   },

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -52,7 +52,7 @@
     "font-awesome": "^4.0.0",
     "jquery": "^2.1.3",
     "jquery-ui": "components/jqueryui#~1.11.2",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.14",
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.22.2",
     "oclazyload": "^1.1.0",

--- a/packages/manager/apps/sign-up/package.json
+++ b/packages/manager/apps/sign-up/package.json
@@ -23,7 +23,7 @@
     "angular-cookies": "^1.7.8",
     "angular-translate": "^2.18.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "ovh-ui-angular": "^3.3.3",
     "ovh-ui-kit": "^2.33.3"
   },

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -34,7 +34,7 @@
     "ip-address": "^5.9.2",
     "jquery": "^2.1.3",
     "jsplumb": "^2.10.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -29,7 +29,7 @@
     "ip-address": "^5.9.2",
     "jquery": "^2.1.3",
     "jsplumb": "^2.10.2",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.14",
     "ng-csv": "^0.3.6",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -29,7 +29,7 @@
     "angular-ui-bootstrap": "~1.3.3",
     "d3": "~3.5.13",
     "jquery": "^2.1.3",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.14",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^7.0.0",

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "bootstrap": "~3.3.0",
     "jsurl": "^0.1.5",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "moment": "^2.24.0",
     "ovh-ui-kit": "^2.33.3"
   },

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^5.1.0"

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "bootstrap4": "twbs/bootstrap#v4.0.0",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^5.1.0"

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -28,7 +28,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-navbar' --include-filtered-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -27,7 +27,7 @@
     "start:watch": "lerna --stream --parallel --scope='@ovh-ux/manager-overthebox' --include-filtered-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "lodash": "4.17.11",
+    "lodash": "4.17.14",
     "moment": "^2.22.2"
   },
   "devDependencies": {

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -28,7 +28,7 @@
     "flag-icon-css": "~0.8.5",
     "ipaddr.js": "^1.9.0",
     "jsurl": "^0.1.5",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "moment": "^2.19",
     "urijs": "^1.19.1",
     "validator": "^10.11.0",

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "jsurl": "^0.1.5",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^5.1.0",

--- a/packages/manager/modules/sign-up/package.json
+++ b/packages/manager/modules/sign-up/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@ovh-ux/manager-config": "^0.3.0",
     "flag-icon-css": "^3.2.0",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^5.1.0"

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "bootstrap4": "twbs/bootstrap#v4.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "moment": "^2.22.2"
   },
   "devDependencies": {

--- a/packages/manager/modules/telecom-dashboard/package.json
+++ b/packages/manager/modules/telecom-dashboard/package.json
@@ -47,7 +47,7 @@
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.14",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -27,7 +27,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-telecom-task' --include-filtered-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^5.1.0"

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "bootstrap4": "twbs/bootstrap#v4.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "moment": "^2.22.2"
   },
   "devDependencies": {

--- a/packages/manager/tools/component-rollup-config/package.json
+++ b/packages/manager/tools/component-rollup-config/package.json
@@ -43,7 +43,7 @@
     "estree-walker": "^0.6.0",
     "less": "^3.9.0",
     "less-plugin-remcalc": "^0.1.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "magic-string": "^0.25.1",
     "node-sass": "^4.10.0",
     "rollup": "^1.15.6",

--- a/packages/manager/tools/webpack-config/package.json
+++ b/packages/manager/tools/webpack-config/package.json
@@ -54,7 +54,7 @@
     "less-loader": "^4.1.0",
     "less-plugin-remcalc": "^0.1.0",
     "loader-utils": "^1.2.3",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.11.0",
     "raw-loader": "^0.5.1",

--- a/packages/manager/tools/webpack-dev-server/package.json
+++ b/packages/manager/tools/webpack-dev-server/package.json
@@ -32,7 +32,7 @@
     "cookie": "^0.3.1",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "friendly-errors-webpack-plugin": "^1.7.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "request": "^2.88.0",
     "webpack-dev-server": "^3.1.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7905,6 +7905,11 @@ lodash@4.17.11, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3,
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@4.17.14, lodash@^4.17.14:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
 lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"


### PR DESCRIPTION
github is reporting high severity security issues on lodash 4.17.11

note : there is still a lodash 3 in yarn.lock because of ovh-api-services, it will also need to be bumped