### PR TITLE
fix(pci-components-region-list): region update

### DIFF
--- a/packages/manager/modules/pci/src/components/project/regions-list/regions-list.controller.js
+++ b/packages/manager/modules/pci/src/components/project/regions-list/regions-list.controller.js
@@ -78,7 +78,8 @@ export default class RegionsListController {
 
   onMacroChange(macro, regions) {
     if (regions.length === 1) {
-      this.onRegionChange(regions[0]);
+      [this.region] = regions;
+      this.onRegionChange(this.region);
     }
   }
 


### PR DESCRIPTION
MANAGER-3036

The region is not being set when only one region is present in a continent.

The region variable is not set correctly so that the select picker is properly displayed when displaySelectedRegion is true.