### PR TITLE
fix(pci-analytics-data-platform): deploy ui nan

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/analytics-data-platform/deploy/storage/storage.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/analytics-data-platform/deploy/storage/storage.controller.js
@@ -1,10 +1,13 @@
+import isUndefined from 'lodash/isUndefined';
+
 import {
   ANALYTICS_DATA_PLATFORM_INPUT_NUMBER_PATTERN,
 } from '../../analytics-data-platform.constants';
 
 export default class {
   /* @ngInject */
-  constructor() {
+  constructor($translate) {
+    this.$translate = $translate;
     this.INPUT_NUMBER_PATTERN = ANALYTICS_DATA_PLATFORM_INPUT_NUMBER_PATTERN;
     this.data = {
       hdfsEffectiveStorage: 0,
@@ -19,5 +22,19 @@ export default class {
 
   dataChange() {
     this.onDataChange({ data: this.data });
+  }
+
+  getStoragePerNode() {
+    return isUndefined(this.data.hdfsEffectiveStorage) ? '-'
+      : `${((this.data.hdfsEffectiveStorage * this.selectedCapability.hdfsReplicationFactor) / this.nodesConfig.worker.count)} ${this.$translate.instant('analytics_data_platform_common_unit_gb')}`;
+  }
+
+  getTotalStorage() {
+    return isUndefined(this.data.hdfsEffectiveStorage) ? '-'
+      : `${(this.data.hdfsEffectiveStorage * this.selectedCapability.hdfsReplicationFactor)} ${this.$translate.instant('analytics_data_platform_common_unit_gb')}`;
+  }
+
+  getTotalEffectiveStorage() {
+    return isUndefined(this.data.edgeNodeStorage) ? '-' : `${(this.data.edgeNodeStorage * this.nodesConfig.edge.count)} ${this.$translate.instant('analytics_data_platform_common_unit_gb')}`;
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/analytics-data-platform/deploy/storage/storage.html
+++ b/packages/manager/modules/pci/src/projects/project/analytics-data-platform/deploy/storage/storage.html
@@ -35,23 +35,13 @@
         <div class="col-sm-6">
             <dl class="storage-list">
                 <dt class="storage-list__term"><span data-translate="analytics_data_platform_deploy_storage_worker_nodes_count"></span> : </dt>
-                <dd class="storage-list__definition"><span data-ng-bind="::$ctrl.nodesConfig.worker.count"></span></dd>
+                <dd class="storage-list__definition" data-ng-bind="::$ctrl.nodesConfig.worker.count"></dd>
                 <dt class="storage-list__term"><span data-translate="analytics_data_platform_deploy_storage_per_node"></span> : </dt>
-                <dd class="storage-list__definition">
-                    <span>
-                        {{ ($ctrl.data.hdfsEffectiveStorage * $ctrl.selectedCapability.hdfsReplicationFactor) / $ctrl.nodesConfig.worker.count }}
-                    </span>
-                    <span data-translate="analytics_data_platform_common_unit_gb"></span>
-                </dd>
+                <dd class="storage-list__definition" data-ng-bind="$ctrl.getStoragePerNode()"></dd>
                 <hr class="storage-list__separator"/>
                 <dt class="storage-list__term"><strong><span data-translate="analytics_data_platform_deploy_storage_total_storage"></span> :</strong></dt>
                 <dd class="storage-list__definition pb-1">
-                    <strong>
-                        <span>
-                            {{ $ctrl.data.hdfsEffectiveStorage * $ctrl.selectedCapability.hdfsReplicationFactor }}
-                        </span>
-                        <span data-translate="analytics_data_platform_common_unit_gb"></span>
-                    </strong>
+                    <strong data-ng-bind="$ctrl.getTotalStorage()"></strong>
                     <button type="button"
                             class="oui-popover-button"
                             data-oui-popover="{{ ::'analytics_data_platform_deploy_storage_replication_factor_popover' | translate: {hdfc_replication_factor: $ctrl.selectedCapability.hdfsReplicationFactor} }}">
@@ -103,15 +93,10 @@
         <div class="col-sm-6">
             <dl class="storage-list">
                 <dt class="storage-list__term"><span data-translate="analytics_data_platform_deploy_storage_edge_nodes_count"></span> : </dt>
-                <dd class="storage-list__definition"><span data-ng-bind="::$ctrl.nodesConfig.edge.count"></span></dd>
+                <dd class="storage-list__definition" data-ng-bind="::$ctrl.nodesConfig.edge.count"></dd>
                 <dt class="storage-list__term"><strong><span data-translate="analytics_data_platform_deploy_storage_total_effective_storage"></span> :</strong></dt>
                 <dd class="storage-list__definition">
-                    <strong>
-                        <span>
-                            {{ $ctrl.data.edgeNodeStorage * $ctrl.nodesConfig.edge.count }}
-                        </span>
-                        <span data-translate="analytics_data_platform_common_unit_gb"></span>
-                    </strong>
+                    <strong data-ng-bind="$ctrl.getTotalEffectiveStorage()"></strong>
                 </dd>
             </dl>
         </div>


### PR DESCRIPTION
MANAGER-3036

The "Stockage brut total" and "Stockage effectif total" fields become NaN when Sotckage effectif du cluster (HDFS) and Stockage par Edge node fields are emptied.

This has been fixed by checking if the input fields are undefined, before computing the other fields' values.