### PR TITLE
refactor(tools.component.rollup.config): remove deprecated languages

### DIFF
--- a/packages/manager/tools/component-rollup-config/src/plugins/translation-utils.ts
+++ b/packages/manager/tools/component-rollup-config/src/plugins/translation-utils.ts
@@ -7,12 +7,7 @@ import startsWith from 'lodash/startsWith';
 const ALL_LANGUAGES = [
   'cs_CZ',
   'de_DE',
-  'en_ASIA',
-  'en_AU',
-  'en_CA',
   'en_GB',
-  'en_SG',
-  'en_US',
   'es_ES',
   'es_US',
   'fi_FI',


### PR DESCRIPTION
# Remove deprecated languages

## :nail_care: Refactor

ea3e246 - refactor(tools.component.rollup.config): remove deprecated languages

## :boom: Breaking Change

keep only the `en_GB` from the languages' list

Removed: 
- en_ASIA
- en_AU
- en_CA
- en_SG
- en_US

## :link: Related

- ovh-ux/manager#1042

## :zap: Performance

| Modules           | Time (before) | Size (before) | Time (after) | Size (after) |
|-------------------|---------------|---------------|--------------|---------------|
| core              | 0m9.318s      | 1.7M          | 0m9.157s     | 1.6M          |
| freefax           | 0m11.732s     | 2.6M          | 0m11.125s    | 2.3M          |
| navbar            | 0m15.959s     | 2.9M          | 0m15.247s    | 2.3M          |
| overthebox        | 0m18.949s     | 7.0M          | 0m17.373s    | 6.0M          |
| pci               | 1m53.596s     | 41M           | 1m27.103s    | 31M           |
| server-sidebar    | 0m9.804s      | 892K          | 0m9.608s     | 860K          |
| sign-up           | 0m13.976s     | 3.1M          | 0m13.042s    | 2.4M          |
| sms               | 0m35.180s     | 16M           | 0m32.059s    | 13M           |
| telecom-dashboard | 0m6.517s      | 660K          | 0m6.534s     | 552K          |
| telecom-task      | 0m7.848s      | 1.2M          | 0m7.509s     | 1.1M          |
| vrack             | 0m12.004s     | 2.2M          | 0m11.504s    | 1.8M          |

With `fr_FR` only:

| Modules           | Time      | Size |
|-------------------|-----------|------|
| core              | 0m9.149s  | 1.3M |
| freefax           | 0m10.565s | 1.7M |
| navbar            | 0m13.084s | 1.2M |
| overthebox        | 0m13.460s | 3.3M |
| pci               | 0m50.790s | 12M  |
| server-sidebar    | 0m9.197s  | 564K |
| sign-up           | 0m11.989s | 1.3M |
| sms               | 0m24.905s | 6.0M |
| telecom-dashboard | 0m6.037s  | 288K |
| telecom-task      | 0m7.308s  | 780K |
| vrack             | 0m10.655s | 984K |

**Time**: uses the following command: `lerna exec --stream --scope='@ovh-ux/manager-PACKAGE_NAME' --include-filtered-dependencies -- yarn run build`.
**Size**: represent the size of the `dist` folder (which contains `cjs`, `esm` and `umd` (if present)).

Tests based on the following commit: `9dcba58581ddd754fc72ff24d2b9408781ae239e`.