### PR TITLE
build(overthebox): add missing `exec` command when using `lerna`

### DIFF
--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -22,9 +22,9 @@
     "dev": "rollup -c --environment BUILD:development",
     "dev:watch": "yarn run dev --watch",
     "prepare": "yarn run build",
-    "start": "lerna --stream --scope='@ovh-ux/manager-overthebox' --include-filtered-dependencies -- yarn run build",
-    "start:dev": "lerna --stream --scope='@ovh-ux/manager-overthebox' --include-filtered-dependencies -- yarn run dev",
-    "start:watch": "lerna --stream --parallel --scope='@ovh-ux/manager-overthebox' --include-filtered-dependencies -- yarn run dev:watch"
+    "start": "lerna exec --stream --scope='@ovh-ux/manager-overthebox' --include-filtered-dependencies -- yarn run build",
+    "start:dev": "lerna exec --stream --scope='@ovh-ux/manager-overthebox' --include-filtered-dependencies -- yarn run dev",
+    "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-overthebox' --include-filtered-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
     "lodash": "4.17.14",


### PR DESCRIPTION
# Add missing `exec` command when using `lerna`

## :gear: Build

7a7b75c - build(overthebox): add missing `exec` command when using `lerna`

## :house: Internal

- No QC required.