### PR TITLE
fix(component-rollup-config): merge array with custom config

### DIFF
--- a/packages/manager/tools/component-rollup-config/src/index.ts
+++ b/packages/manager/tools/component-rollup-config/src/index.ts
@@ -1,4 +1,4 @@
-import { get, isString, merge } from 'lodash';
+import { get, isString, mergeWith } from 'lodash';
 import babel from 'rollup-plugin-babel';
 import camelcase from 'camelcase';
 import commonjs from 'rollup-plugin-commonjs';
@@ -19,6 +19,10 @@ import translationXML from './plugins/translation-xml';
 
 const defaultName = path.basename(process.cwd());
 
+const mergeConfig = (config, customConfig) => mergeWith(config, customConfig, (obj, src) => (
+  Array.isArray(obj) && Array.isArray(src) ? src.concat(obj) : undefined
+));
+
 const getLanguages = (pluginsOpts) => {
   if (isString(process.env.LANGUAGES)) {
     return process.env.LANGUAGES.split('-');
@@ -26,7 +30,7 @@ const getLanguages = (pluginsOpts) => {
   return get(pluginsOpts, 'translations.languages');
 };
 
-const generateConfig = (opts, pluginsOpts) => Object.assign({
+const generateConfig = (opts, pluginsOpts) => mergeConfig({
   plugins: [
     peerdeps(),
     html(),
@@ -74,7 +78,7 @@ const generateConfig = (opts, pluginsOpts) => Object.assign({
   ],
 }, opts);
 
-const cjs = (opts, pluginsOpts) => generateConfig(merge({
+const cjs = (opts, pluginsOpts) => generateConfig(mergeConfig({
   output: {
     dir: './dist/cjs',
     format: 'cjs',
@@ -82,7 +86,7 @@ const cjs = (opts, pluginsOpts) => generateConfig(merge({
   },
 }, opts), pluginsOpts);
 
-const umd = (opts, pluginsOpts) => generateConfig(merge({
+const umd = (opts, pluginsOpts) => generateConfig(mergeConfig({
   inlineDynamicImports: true,
   output: {
     name: defaultName,
@@ -92,7 +96,7 @@ const umd = (opts, pluginsOpts) => generateConfig(merge({
   },
 }, opts), pluginsOpts);
 
-const es = (opts, pluginsOpts) => generateConfig(merge({
+const es = (opts, pluginsOpts) => generateConfig(mergeConfig({
   output: {
     dir: './dist/esm',
     format: 'es',
@@ -100,7 +104,7 @@ const es = (opts, pluginsOpts) => generateConfig(merge({
   },
 }, opts), pluginsOpts);
 
-const iife = (opts, pluginsOpts) => generateConfig(merge({
+const iife = (opts, pluginsOpts) => generateConfig(mergeConfig({
   inlineDynamicImports: true,
   output: {
     name: camelcase(defaultName),
@@ -111,10 +115,10 @@ const iife = (opts, pluginsOpts) => generateConfig(merge({
 }, opts), pluginsOpts);
 
 const config = (globalOpts = {}, pluginsOpts = {}) => ({
-  cjs: (opts = {}) => cjs(merge(opts, globalOpts), pluginsOpts),
-  es: (opts = {}) => es(merge(opts, globalOpts), pluginsOpts),
-  iife: (opts = {}) => iife(merge(opts, globalOpts), pluginsOpts),
-  umd: (opts = {}) => umd(merge(opts, globalOpts), pluginsOpts),
+  cjs: (opts = {}) => cjs(mergeConfig(opts, globalOpts), pluginsOpts),
+  es: (opts = {}) => es(mergeConfig(opts, globalOpts), pluginsOpts),
+  iife: (opts = {}) => iife(mergeConfig(opts, globalOpts), pluginsOpts),
+  umd: (opts = {}) => umd(mergeConfig(opts, globalOpts), pluginsOpts),
 });
 
 config.plugins = {


### PR DESCRIPTION
**issue :**
when adding some plugins in a custom rollup configuration file, the custom array overrides the component-rollup-config default's list of plugins
```javascript
const rollupConfig = require('@ovh-ux/component-rollup-config');
const config = rollupConfig({
  plugins: ['foo'],
});
console.log(config.es().plugins); // equals ['foo'] ...
```

**fix :**
use `mergeWith` instead of `merge` or `assign` to concatenate arrays instead of overriding them