### PR TITLE
fix(office): remove deprecated scripts in package.json

### DIFF
--- a/packages/manager/modules/office/package.json
+++ b/packages/manager/modules/office/package.json
@@ -11,15 +11,6 @@
   "license": "BSD-3-Clause",
   "author": "OVH SAS",
   "main": "./src/index.js",
-  "scripts": {
-    "build": "rollup -c --environment BUILD:production",
-    "dev": "rollup -c --environment BUILD:development",
-    "dev:watch": "node ../../../../scripts/rollup-dev-builder",
-    "prepare": "yarn run build",
-    "start": "lerna exec --stream --scope='@ovh-ux/manager-office' --include-filtered-dependencies -- yarn run build",
-    "start:dev": "lerna exec --stream --scope='@ovh-ux/manager-office' --include-filtered-dependencies -- yarn run dev",
-    "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-office' --include-filtered-dependencies -- yarn run dev:watch"
-  },
   "dependencies": {
     "jsurl": "^0.1.4",
     "lodash": "^4.17.14",


### PR DESCRIPTION
prepare hook was causing a build error because rollug.config.js file does not exist anymore