### PR TITLE
fix(pci): missing user creation translation message

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/users/add/user-add/index.js
+++ b/packages/manager/modules/pci/src/projects/project/users/add/user-add/index.js
@@ -14,6 +14,7 @@ angular
     'pascalprecht.translate',
   ])
   .component('pciProjectUsersAdd', component)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .run(/* @ngTranslationsInject:json ./translations */)
+  .run(/* @ngTranslationsInject:json ../roles/translations */);
 
 export default moduleName;


### PR DESCRIPTION
Related to DTRUN-2431

issue : user creation message was not displayed (and so the associated password...)

fix : add missing translations