### PR TITLE
fix(sharepoint.activate): display alert message correctly

### DIFF
--- a/packages/manager/modules/sharepoint/src/activate/sharepoint-activate.controller.js
+++ b/packages/manager/modules/sharepoint/src/activate/sharepoint-activate.controller.js
@@ -26,10 +26,10 @@ export default class SharepointActivateOfficeCtrl {
         .then(() => {
           this.alerter.success(
             this.$translate.instant('sharepoint_action_activate_office_licence_success_message', { t0: this.account.userPrincipalName }),
-            this.$scope.alerts.dashboard,
+            this.$scope.alerts.main,
           );
         })
-        .catch(err => this.alerter.alertFromSWS(this.$translate.instant('sharepoint__action_activate_office_licence_error_message'), err, this.$scope.alerts.dashboard))
+        .catch(err => this.alerter.alertFromSWS(this.$translate.instant('sharepoint__action_activate_office_licence_error_message'), err, this.$scope.alerts.main))
         .finally(() => this.$scope.resetAction());
     };
   }


### PR DESCRIPTION
# Display alert message correctly

## :bug: Bug Fix

a0b97fe - fix(sharepoint.activate): display alert message correctly

## :link: Related

- ovh-ux/ovh-module-sharepoint#135
- ovh-ux/ovh-manager-web#1173

## :house: Internal

ref: MANAGER-3097