### PR TITLE
build(deps): upgrade ng-ovh-telecom-universe-components to v3.0.6

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -21,7 +21,7 @@
     "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.1.0",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-tail-logs": "^2.0.0-beta.1",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@uirouter/angularjs": "^1.0.15",

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -19,7 +19,7 @@
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.1.0",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -20,7 +20,7 @@
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-checkbox-table": "^1.0.0",
     "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-pagination-front": "^8.0.0-alpha.0",
     "@uirouter/angularjs": "^1.0.15",
     "CSV-JS": "^1.2.0",

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -17,7 +17,7 @@
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@uirouter/angularjs": "^1.0.15",
     "CSV-JS": "^1.2.0",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -17,7 +17,7 @@
     "@ovh-ux/manager-core": "^6.0.1",
     "@ovh-ux/manager-telecom-styles": "^3.0.0",
     "@ovh-ux/manager-telecom-task": "^4.1.1",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@uirouter/angularjs": "^1.0.15",
     "CSV-JS": "^1.2.0",

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -37,7 +37,7 @@
     "@ovh-ux/manager-core": "^6.1.1",
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -37,7 +37,7 @@
     "@ovh-ux/manager-core": "^6.1.1",
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-tail-logs": "^2.0.0-beta.1",
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -50,7 +50,7 @@
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",
     "@ovh-ux/ng-ovh-checkbox-table": "^1.0.0",
     "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-pagination-front": "^8.0.0-alpha.0",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",

--- a/packages/manager/modules/telecom-dashboard/package.json
+++ b/packages/manager/modules/telecom-dashboard/package.json
@@ -42,7 +42,7 @@
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@ovh-ux/manager-core": "^6.1.2",
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
-    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.3",
+    "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.6",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,10 +1824,10 @@
   dependencies:
     lodash "^4.17.11"
 
-"@ovh-ux/ng-ovh-telecom-universe-components@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-telecom-universe-components/-/ng-ovh-telecom-universe-components-3.0.3.tgz#77b69d1365cc23ea7f091868813061800e5c8d6f"
-  integrity sha512-wP4WsXfesglJp4PbmMboryKhX/QUbkX/ESUwvKbvERp57AR6rX2jCXcixpOXD8xI9ORtuWSK0A/9vI1lvoySyg==
+"@ovh-ux/ng-ovh-telecom-universe-components@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-telecom-universe-components/-/ng-ovh-telecom-universe-components-3.0.6.tgz#af2f2f032282259bd52ecbbceb8437ca2f8c02c3"
+  integrity sha512-+nsk3DOYEFCQOOCFZYb9sHk5KHfVxv9ogaGy5trjcwZAcTkWG+8FU04dKeb04j4sPH1xyFIG7iqzAECD92mD3A==
   dependencies:
     bootstrap "^3.3.7"
     ovh-ui-kit "^2.22.0"


### PR DESCRIPTION
# Upgrade ng-ovh-telecom-universe-components to v3.0.6

## ⬆️ Upgrade

e3dd3ea - build(deps): upgrade ng-ovh-telecom-universe-components to v3.0.6

uses: `yarn upgrade-interactive --latest`
- @ovh-ux/ng-ovh-telecom-universe-components@3.0.6

## 🔗 Related

- ovh-ux/ng-ovh-telecom-universe-components#113

## 🏠 Internal

- No QC required.