### PR TITLE
fix(users): avoid scroll roles matrix

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/users/roles-matrix/roles-matrix.less
+++ b/packages/manager/modules/pci/src/projects/project/users/roles-matrix/roles-matrix.less
@@ -26,5 +26,10 @@
       border-left: none;
       box-shadow: none;
     }
+
+    .oui-datagrid__header {
+      padding: 0.125rem 0.25rem;
+      white-space: unset;
+    }
   }
 }


### PR DESCRIPTION
Enable word wrap for column headers and remove extra padding

MBP-521