### PR TITLE
fix(core): remove extra cs_CZ language from constant file

### DIFF
--- a/packages/manager/modules/core/src/manager-core.constants.js
+++ b/packages/manager/modules/core/src/manager-core.constants.js
@@ -32,9 +32,6 @@ export const LANGUAGES = {
   }, {
     name: 'Suomi',
     key: 'fi_FI',
-  }, {
-    name: 'Česky',
-    key: 'cs_CZ',
   }],
   defaultLoc: 'fr_FR',
   fallback: 'fr_FR',


### PR DESCRIPTION
# Remove extra `cs_CZ` language from constant file

## :bug: Bug Fix

90e0bcc - fix(core): remove extra cs_CZ language from constant file

## :house: Internal

- No QC required.