### PR TITLE
fix(core): remove extra nl_NL language from constant file

### DIFF
--- a/packages/manager/modules/core/src/manager-core.constants.js
+++ b/packages/manager/modules/core/src/manager-core.constants.js
@@ -21,9 +21,6 @@ export const LANGUAGES = {
     name: 'Lietuviškai',
     key: 'lt_LT',
   }, {
-    name: 'Nederlands',
-    key: 'nl_NL',
-  }, {
     name: 'Polski',
     key: 'pl_PL',
   }, {


### PR DESCRIPTION
# Remove extra `nl_NL` language from constant file

## :bug: Bug Fix

5894184 - fix(core): remove extra nl_NL language from constant file

## :house: Internal

- No QC required.