### PR TITLE
fix(theme): navbar overlap

### DIFF
--- a/packages/manager/apps/public-cloud/src/assets/theme/_navbar.less
+++ b/packages/manager/apps/public-cloud/src/assets/theme/_navbar.less
@@ -8,7 +8,7 @@
 .oui-navbar {
   background-color: #fff;
   box-shadow: 0 2pt 4pt rgba(17, 63, 109, 0.15);
-  z-index: 2;
+  z-index: 3;
 
   .oui-navbar__brand {
     color: rgb(40, 89, 192);


### PR DESCRIPTION
In mobile view, the clipboard icon (if it is available) overlaps with the navbar. This is because the z-index of both the clipboard icon and the side bar is 2.
To fix this issue, the z-index for the navbar is increased to 3

MBP-541