### PR TITLE
fix(server-sidebar): redirect nasha to cloud manager

### DIFF
--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -39,7 +39,7 @@
     "@ovh-ux/manager-config": "^0.3.0",
     "@ovh-ux/manager-core": "^6.1.1",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.1",
-    "@ovh-ux/ng-ovh-sidebar-menu": "^8.3.2",
+    "@ovh-ux/ng-ovh-sidebar-menu": "^8.4.0",
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/server-sidebar/src/sidebar.constants.js
+++ b/packages/manager/modules/server-sidebar/src/sidebar.constants.js
@@ -90,20 +90,18 @@ export const NETWORKS_CONFIG = {
     },
     {
       path: '/dedicated/nasha',
-      state: 'app.networks.nas.details',
-      stateParams: ['nasId'],
-      stateParamsTransformer: params => ({
-        ...params,
-        nasType: 'nas',
-        nasId: `nasha_${params.nasId}`,
-      }),
+      state: 'paas.nasha.nasha-partitions',
+      stateParams: ['nashaId'],
       icon: 'ovh-font ovh-font-cloudnas',
-      app: [DEDICATED],
+      app: [CLOUD],
       regions: ['EU', 'CA'],
       searchKeys: ['NAS', 'NASHA', 'NAS-HA'],
     },
   ],
-  loadOnState: 'app.networks',
+  loadOnState: [
+    'paas.nasha.nasha-partitions',
+    'app.networks',
+  ],
   icon: 'ovh-font ovh-font-network',
   app: [DEDICATED],
   regions: ['EU', 'CA'],
@@ -182,7 +180,11 @@ export const IAAS_CONFIG = {
 
 export const PAAS_CONFIG = {
   id: 'paas',
-  loadOnState: 'paas',
+  loadOnState: [
+    'paas.cda',
+    'paas.veeam.detail',
+    'paas.veeam-enterprise',
+  ],
   types: [
     {
       path: '/dedicated/ceph',


### PR DESCRIPTION
## fix(server-sidebar): redirect nasha to cloud manager

### Description of the Change

ref: DTRUN-2650

fbb026d97 — fix(server-sidebar): redirect nasha to cloud manager

### Related PRs:

- [x] Merge & release https://github.com/ovh-ux/ng-ovh-sidebar-menu/pull/78 (`@ovh-ux/ng-ovh-sidebar-menu@8.4.0`)
- [x] merge 2api `/service`
