### PR TITLE
fix(pci.project.kubernetes.details.service): adjust popover placement

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/service.html
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/service.html
@@ -84,8 +84,8 @@
                 <dl class="oui-tile__definition">
                     <dt class="oui-tile__term">
                         <span data-translate="kube_service_file"></span>
-                        <oui-popover>
-                            <button type="button" class="oui-popover-button" oui-popover-trigger></button>
+                        <oui-popover data-oui-popover-placement="auto">
+                            <button type="button" class="oui-popover-button" data-oui-popover-trigger></button>
                             <oui-popover-content>
                                 <span data-translate="kube_service_file_help"></span>
                                 <a class="oui-link oui-link_icon"


### PR DESCRIPTION
Set popover placement to auto so that it auto-adjusts for mobile view and does not get clipped

MBP-540