### PR TITLE
fix(sms.order): display correctly the quantity field

### DIFF
--- a/packages/manager/modules/sms/src/order/telecom-sms-order-service.html
+++ b/packages/manager/modules/sms/src/order/telecom-sms-order-service.html
@@ -61,12 +61,12 @@
                                class="control-label"
                                data-translate="sms_order_credit_custom_label">
                         </label>
-                        <input-number-spinner class="float-left"
-                                              data-ng-model="$ctrl.order.customCredit"
-                                              data-input-number-spinner-min="$ctrl.order.min"
-                                              data-input-number-spinner-max="$ctrl.order.max"
-                                              data-input-number-spinner-on-change="$ctrl.getDebouncedPrices()">
-                        </input-number-spinner>
+                        <oui-numeric
+                            data-min="$ctrl.order.min"
+                            data-max="$ctrl.order.max"
+                            data-model="$ctrl.order.customCredit"
+                            data-on-change="$ctrl.getDebouncedPrices()">
+                        </oui-numeric>
                     </div>
 
                     <div data-ng-if="!$ctrl.loading.prices">


### PR DESCRIPTION
# Display correctly the quantity field

replace `input-number-spinner` by `oui-numeric` component.

## 🐛 Bug Fix

43f073a - fix(sms.order): display correctly the quantity field

## 🔗 Related

fix #1175