### PR TITLE
build(apps.web): upgrade server-sidebar to v0.5.0

### DIFF
--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -34,7 +34,7 @@
     "@ovh-ux/manager-navbar": "^1.2.3",
     "@ovh-ux/manager-office": "^1.0.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
-    "@ovh-ux/manager-server-sidebar": "^0.4.2",
+    "@ovh-ux/manager-server-sidebar": "^0.5.0",
     "@ovh-ux/manager-sharepoint": "^1.0.0",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",


### PR DESCRIPTION
# Upgrade server-sidebar to v0.5.0

Due to `yarn install` that generate a diff in `yarn.lock` file based on the latest commit from the `master` branch (8a90259bdc6c9dae2a6c56e4bca1d95fcc53dd23)

## :arrow_up: Upgrade

555d81a - build(apps.web): upgrade server-sidebar to v0.5.0