### PR TITLE
test(remark): exclude CHANGELOG.md file from lint-staged configuration

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -10,7 +10,7 @@
     "stylelint 'packages/**/*.less' --fix",
     "git add"
   ],
-  "*.md": [
+  "!(*CHANGELOG).md": [
     "remark -qf ."
   ]
 }


### PR DESCRIPTION
# Update `lint-staged` configuration

`remark` can be run via the `lint-staged` configuration but it mean that the `.remarkignore` file isn't taking in account.

Some people reported this issue when resolving merge conflicts for instance and can't commit their changes due the `CHANGELOG.md` file because it was auto generated by `conventional-changelog` script.

## :white_check_mark: Test

20c235a - test(remark): exclude CHANGELOG.md file from lint-staged configuration

## 🏠 Internal

- No QC required.
