### PR TITLE
build(deps): upgrade ng-ovh-sso-auth to v4.2.1

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -21,7 +21,7 @@
     "@ovh-ux/ng-ovh-contracts": "^3.0.0-beta.3",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
-    "@ovh-ux/ng-ovh-sso-auth": "^4.2.0",
+    "@ovh-ux/ng-ovh-sso-auth": "^4.2.1",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.9",
     "@ovh-ux/ng-tail-logs": "^2.0.0-beta.1",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -19,7 +19,7 @@
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.2",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
-    "@ovh-ux/ng-ovh-sso-auth": "^4.2.0",
+    "@ovh-ux/ng-ovh-sso-auth": "^4.2.1",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.9",
     "@ovh-ux/ng-uirouter-title": "^2.0.0-beta.3",
     "@uirouter/angularjs": "^1.0.15",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -31,7 +31,7 @@
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",
-    "@ovh-ux/ng-ovh-sso-auth": "^4.2.0",
+    "@ovh-ux/ng-ovh-sso-auth": "^4.2.1",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",
     "@ovh-ux/ng-ovh-user-pref": "^1.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",

--- a/packages/manager/apps/sign-up/package.json
+++ b/packages/manager/apps/sign-up/package.json
@@ -16,7 +16,7 @@
     "@ovh-ux/manager-config": "^0.3.0",
     "@ovh-ux/manager-core": "^7.1.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
-    "@ovh-ux/ng-ovh-sso-auth": "^4.2.0",
+    "@ovh-ux/ng-ovh-sso-auth": "^4.2.1",
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "@ovh-ux/sign-up": "^1.0.0",
     "@uirouter/angularjs": "^1.0.20",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -56,7 +56,7 @@
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
     "@ovh-ux/ng-ovh-sidebar-menu": "^8.4.1",
     "@ovh-ux/ng-ovh-simple-country-list": "^1.0.0",
-    "@ovh-ux/ng-ovh-sso-auth": "^4.2.0",
+    "@ovh-ux/ng-ovh-sso-auth": "^4.2.1",
     "@ovh-ux/ng-ovh-sso-auth-modal-plugin": "^3.0.1",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.9",

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -48,7 +48,7 @@
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",
     "@ovh-ux/ng-ovh-sidebar-menu": "^8.4.1",
-    "@ovh-ux/ng-ovh-sso-auth": "^4.2.0",
+    "@ovh-ux/ng-ovh-sso-auth": "^4.2.1",
     "@ovh-ux/ng-ovh-sso-auth-modal-plugin": "^3.0.1",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",
     "@ovh-ux/ng-ovh-user-pref": "^1.0.0",

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
-    "@ovh-ux/ng-ovh-sso-auth": "^4.2.0",
+    "@ovh-ux/ng-ovh-sso-auth": "^4.2.1",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",
     "@uirouter/angularjs": "^1.0.20",
     "angular": "^1.7.5",

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -40,7 +40,7 @@
     "@ovh-ux/manager-core": "^7.1.0",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-ovh-chatbot": "^2.0.1",
-    "@ovh-ux/ng-ovh-sso-auth": "^4.2.0",
+    "@ovh-ux/ng-ovh-sso-auth": "^4.2.1",
     "@ovh-ux/ng-ovh-user-pref": "^1.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "angular": "^1.7.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,10 +1905,10 @@
   dependencies:
     lodash "~4.17.11"
 
-"@ovh-ux/ng-ovh-sso-auth@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-sso-auth/-/ng-ovh-sso-auth-4.2.0.tgz#9605e42686b09810d51355da8402089e4e30305d"
-  integrity sha512-SycWgJZwSM7GzaNaf8KxVvpR8CDnJqgIdememr+fcUb8N89z7rxkM5lWsDKdjTrKxjuxQ2xctDEOx7DKrfmSww==
+"@ovh-ux/ng-ovh-sso-auth@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-sso-auth/-/ng-ovh-sso-auth-4.2.1.tgz#e0998ff2cc04308730c484ec3e68882438194498"
+  integrity sha512-rQX1q4SV9U7g7yo7lFPzEqtpgZHVeME4tdSO+Qg8w8W8Bf6/xjIftJ0fRL43ykIDaZDc7+P2dmLy9cnwGv0Xsw==
 
 "@ovh-ux/ng-ovh-swimming-poll@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
# Upgrade ng-ovh-sso-auth to v4.2.1

## :arrow_up: Upgrade

build(deps): upgrade ng-ovh-sso-auth to v4.2.1

uses: `yarn upgrade-interactive --latest @ovh-ux/ng-ovh-sso-auth`
- @ovh-ux/ng-ovh-sso-auth@4.2.1

## :house: Interrnal

- No QC required.