### PR TITLE
feat(tools.webpack.dev.server.config): add port option to env object

### DIFF
--- a/packages/manager/tools/webpack-dev-server/README.md
+++ b/packages/manager/tools/webpack-dev-server/README.md
@@ -29,17 +29,18 @@ The _env_ parameter is an object containing the following values:
 
 ```js
 const env = {
-  host: '0.0.0.0',  // If you want your server to be accessible externally 
+  dev: [            // custom configuration to proxy some routes
+    {
+      context,      // Routes to rewrite
+      nic,
+      target,       // API path to target
+    }
+  ],
+  host: '0.0.0.0',  // If you want your server to be accessible externally
   https: false,     // true to enable https
   local2API: false, // true to make 2API calls on local 8080 port
+  port: 9000,       // Specify a port number to listen for requests.
   region: 'EU',     // manager region (EU, CA, US)
-  dev: [            // custom configuration to proxy some routes 
-    {
-      context       // Routes to rewrite
-      target        // API path to target
-      nic           
-    }
-  ]
 };
 ```
 

--- a/packages/manager/tools/webpack-dev-server/src/config.ts
+++ b/packages/manager/tools/webpack-dev-server/src/config.ts
@@ -30,10 +30,10 @@ export = (env) => {
       },
       clientLogLevel: 'none',
       logLevel: 'silent',
+      host: env.host || 'localhost',
       https: env.https || false,
       overlay: true,
-      host: env.host || 'localhost',
-      port: 9000,
+      port: env.port || 9000,
       proxy,
     },
   };


### PR DESCRIPTION
# Add `port` option to env object

With the actual configuration we are not able to launch multiple applications
because it always results with this following error:

```sh
$ webpack-dev-server --env.region=eu

● OVH Manager █████████████████████████ compiling (0%)  
 

events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use 127.0.0.1:9000
    at Server.setupListenHandle [as _listen2] (net.js:1290:14)
    at listenInCluster (net.js:1338:12)
    at GetAddrInfoReqWrap.doListen [as callback] (net.js:1471:7)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:62:10)
Emitted 'error' event at:
    at emitErrorNT (net.js:1317:8)
    at process._tickCallback (internal/process/next_tick.js:63:19)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```

## :sparkles: Feature

6e3470b - feat(tools.webpack.dev.server.config): add port option to env object

## :mag: Examples

We now are able to pass the `port` option like this:

```diff
diff --git a/package.json b/package.json
index 920d9ae3bac4..d61441aacb4e 100644
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:css": "stylelint 'client/**/*.less' --fix",
     "lint:html": "htmlhint 'client/**/*.html'",
     "lint:js": "eslint --quiet --fix --format=pretty ./client",
-    "start": "webpack-dev-server --env.region=eu",
+    "start": "webpack-dev-server --env.region=eu --env.port=9001",
     "test": "yarn run lint",
     "version": "npx conventional-changelog-cli -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
     "postversion": "git push && git push --tags"
```

## :link: Related

- https://webpack.js.org/configuration/dev-server/#devserverport