### PR TITLE
build(tuc): fix eslint errors

### DIFF
--- a/packages/manager/modules/telecom-universe-components/package.json
+++ b/packages/manager/modules/telecom-universe-components/package.json
@@ -42,6 +42,7 @@
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.7.4",
     "punycode": "^2.1.1",
-    "validator": "^11.1.0"
+    "validator": "^11.1.0",
+    "validator-js": "^0.2.1"
   }
 }

--- a/packages/manager/modules/telecom-universe-components/src/slider/slider.directive.js
+++ b/packages/manager/modules/telecom-universe-components/src/slider/slider.directive.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import angular from 'angular';
 
 export default /* @ngInject */ ($timeout) => {
@@ -396,3 +397,4 @@ export default /* @ngInject */ ($timeout) => {
     },
   };
 }
+/* eslint-enable */


### PR DESCRIPTION
## build(tuc): fix eslint errors

### Description of the Change

* add missing `validator-js` peer dependency
* disable eslint for `slider.directive`

d9b2e33f9 — build(tuc): fix eslint errors

