### PR TITLE
fix(support): refactoring, fix some ux synchonization glitches

### DIFF
--- a/packages/manager/modules/support/src/tickets/new-ticket/creation-form/creation-form.component.js
+++ b/packages/manager/modules/support/src/tickets/new-ticket/creation-form/creation-form.component.js
@@ -3,7 +3,7 @@ import template from './creation-form.html';
 
 export default {
   bindings: {
-    issues: '<',
+    issue: '<',
     onSubmit: '&',
   },
   controller,

--- a/packages/manager/modules/support/src/tickets/new-ticket/creation-form/creation-form.controller.js
+++ b/packages/manager/modules/support/src/tickets/new-ticket/creation-form/creation-form.controller.js
@@ -1,5 +1,4 @@
-import findLast from 'lodash/findLast';
-import last from 'lodash/last';
+import get from 'lodash/get';
 
 export default class SupportNewCreationFormController {
   /* @ngInject */
@@ -20,12 +19,7 @@ export default class SupportNewCreationFormController {
   }
 
   get subject() {
-    const issue = findLast(this.issues, 'subject');
-    return issue ? issue.subject : undefined;
-  }
-
-  getLastIssue() {
-    return last(this.issues);
+    return get(this.issue, 'subject');
   }
 
   shouldSelectUrgency() {
@@ -36,7 +30,7 @@ export default class SupportNewCreationFormController {
     this.onSubmit({
       result: {
         isSuccess,
-        issues: this.issues,
+        issue: this.issue,
         subject: this.subject || this.customSubject,
         urgency: this.urgency,
       },

--- a/packages/manager/modules/support/src/tickets/new-ticket/creation-form/creation-form.html
+++ b/packages/manager/modules/support/src/tickets/new-ticket/creation-form/creation-form.html
@@ -22,7 +22,7 @@
                class="oui-input" />
     </oui-field>
 
-    <oui-field data-ng-repeat="field in $ctrl.getLastIssue().fields track by field.id"
+    <oui-field data-ng-repeat="field in $ctrl.issue.fields track by field.id"
                data-label="{{ field.label }}"
                data-size="xl">
         <input type="text"

--- a/packages/manager/modules/support/src/tickets/new-ticket/issues-form/issues-form.controller.js
+++ b/packages/manager/modules/support/src/tickets/new-ticket/issues-form/issues-form.controller.js
@@ -2,6 +2,8 @@ import filter from 'lodash/filter';
 import get from 'lodash/get';
 import orderBy from 'lodash/orderBy';
 
+const CATEGORY_ACCOUNT = 'account';
+
 export default class SupportNewIssuesFormController {
   /* @ngInject */
   constructor(
@@ -20,6 +22,7 @@ export default class SupportNewIssuesFormController {
     this.OvhApiSupport = OvhApiSupport;
     this.OvhApiMe = OvhApiMe;
     this.SupportNewTicketService = SupportNewTicketService;
+    this.CATEGORY_ACCOUNT = CATEGORY_ACCOUNT;
   }
 
   $onInit() {
@@ -60,7 +63,7 @@ export default class SupportNewIssuesFormController {
     this.service = null;
     this.isUnknownService = false;
     this.issue = null;
-    if (this.category.id === 'account') {
+    if (this.category.id === CATEGORY_ACCOUNT) {
       this.issueParams = {
         category: this.category,
         serviceType: undefined,

--- a/packages/manager/modules/support/src/tickets/new-ticket/issues-form/issues-form.html
+++ b/packages/manager/modules/support/src/tickets/new-ticket/issues-form/issues-form.html
@@ -2,12 +2,12 @@
       name="supportNewIssuesForm">
 
     <div class="text-center">
-        <oui-spinner data-ng-if="$ctrl.loading"
+        <oui-spinner data-ng-if="$ctrl.isLoading"
                      data-size="l">
         </oui-spinner>
     </div>
 
-    <div data-ng-if="!$ctrl.loading">
+    <div data-ng-if="!$ctrl.isLoading">
         <oui-field data-label="{{:: 'ovhManagerSupport_new_category' | translate }}"
                    data-size="xl">
             <oui-select name="category"
@@ -49,17 +49,16 @@
             </oui-checkbox>
         </oui-field>
 
-        <div data-ng-if="$ctrl.isUnknownService || $ctrl.service || $ctrl.category.id === 'account'">
+        <div data-ng-if="$ctrl.issueParams && ($ctrl.isUnknownService || $ctrl.service || $ctrl.category.id === 'account')">
             <support-issues-selector
-                data-root="true"
-                data-category="$ctrl.category"
-                data-service-type="$ctrl.serviceType"
-                data-on-issues="$ctrl.onIssues(issues)">
+                data-category="$ctrl.issueParams.category"
+                data-service-type="$ctrl.issueParams.serviceType"
+                data-issue="$ctrl.issue">
             </support-issues-selector>
         </div>
 
         <div class="w-75"
-             data-ng-if="$ctrl.issues && $ctrl.issues.length > 0 && ($ctrl.isUnknownService || $ctrl.service || $ctrl.services.length === 0)">
+             data-ng-if="$ctrl.issue">
             <oui-tile data-ng-if="$ctrl.guides.length || $ctrl.tips.length">
                 <h2 data-translate="ovhManagerSupport_new_guides"
                     data-ng-if="$ctrl.guides.length">

--- a/packages/manager/modules/support/src/tickets/new-ticket/issues-form/issues-form.html
+++ b/packages/manager/modules/support/src/tickets/new-ticket/issues-form/issues-form.html
@@ -18,7 +18,7 @@
             </oui-select>
         </oui-field>
         <oui-field data-label="{{:: 'ovhManagerSupport_new_serviceType' | translate }}"
-                   data-ng-if="$ctrl.category && $ctrl.category.id !== 'account'"
+                   data-ng-if="$ctrl.category && $ctrl.category.id !== $ctrl.CATEGORY_ACCOUNT"
                    data-size="xl">
             <oui-select name="serviceType"
                         data-model="$ctrl.serviceType"
@@ -33,7 +33,7 @@
             </oui-spinner>
         </div>
         <oui-field data-label="{{:: 'ovhManagerSupport_new_service' | translate }}"
-                   data-ng-if="$ctrl.serviceType && $ctrl.category.id !== 'account' && $ctrl.services !== null"
+                   data-ng-if="$ctrl.serviceType && $ctrl.category.id !== $ctrl.CATEGORY_ACCOUNT && $ctrl.services !== null"
                    data-size="xl">
             <oui-select name="service"
                         data-model="$ctrl.service"
@@ -49,7 +49,7 @@
             </oui-checkbox>
         </oui-field>
 
-        <div data-ng-if="$ctrl.issueParams && ($ctrl.isUnknownService || $ctrl.service || $ctrl.category.id === 'account')">
+        <div data-ng-if="$ctrl.issueParams && ($ctrl.isUnknownService || $ctrl.service || $ctrl.category.id === $ctrl.CATEGORY_ACCOUNT)">
             <support-issues-selector
                 data-category="$ctrl.issueParams.category"
                 data-service-type="$ctrl.issueParams.serviceType"

--- a/packages/manager/modules/support/src/tickets/new-ticket/issues-selector/issues-selector.component.js
+++ b/packages/manager/modules/support/src/tickets/new-ticket/issues-selector/issues-selector.component.js
@@ -5,10 +5,8 @@ export default {
   bindings: {
     category: '<',
     serviceType: '<',
-    rank: '<',
-    root: '<',
-    parent: '<',
-    onIssues: '&',
+    parentIssue: '<',
+    issue: '=',
   },
   controller,
   name: 'supportIssuesSelector',

--- a/packages/manager/modules/support/src/tickets/new-ticket/issues-selector/issues-selector.html
+++ b/packages/manager/modules/support/src/tickets/new-ticket/issues-selector/issues-selector.html
@@ -1,24 +1,22 @@
-<oui-spinner data-ng-if="$ctrl.canFetchIssues() && !$ctrl.issueTypes">
+<oui-spinner data-ng-if="$ctrl.isLoading && !$ctrl.issueTypes">
 </oui-spinner>
 
 <oui-field data-label="{{ ('ovhManagerSupport_new_issue' | translate) + ' ' + $ctrl.rank }}"
-           data-ng-if="$ctrl.canFetchIssues() && $ctrl.issueTypes.length"
+           data-ng-if="!$ctrl.isLoading && $ctrl.issueTypes.length"
            data-size="xl">
     <oui-select name="issue"
                 data-model="$ctrl.issueType"
                 data-items="$ctrl.issueTypes"
                 data-disabled="!$ctrl.issueTypes.length"
-                data-on-change="$ctrl.onIssueTypeChange()"
+                data-on-change="$ctrl.onIssueTypeSelected()"
                 data-match="label">
     </oui-select>
 </oui-field>
 
 <support-issues-selector
     data-ng-if="$ctrl.issueType.hasChildren"
-    data-rank="$ctrl.rank + 1"
-    data-root="$ctrl.issueType.id"
-    data-parent="$ctrl"
-    data-on-issues="$ctrl.onIssues(issues)"
     data-category="$ctrl.category"
-    data-service-type="$ctrl.serviceType">
+    data-service-type="$ctrl.serviceType"
+    data-parent-issue="$ctrl.issueType"
+    data-issue="$ctrl.issue">
 </support-issues-selector>

--- a/packages/manager/modules/support/src/tickets/new-ticket/new-ticket.html
+++ b/packages/manager/modules/support/src/tickets/new-ticket/new-ticket.html
@@ -9,7 +9,7 @@
 
 <support-new-creation-form
     id="creationForm"
-    data-issues="$ctrl.issues"
+    data-issue="$ctrl.issue"
     data-ng-show="$ctrl.step === 'creation'"
     data-on-submit="$ctrl.onCreationFormSubmit(result)">
 </support-new-creation-form>

--- a/packages/manager/modules/support/src/tickets/new-ticket/new-ticket.service.js
+++ b/packages/manager/modules/support/src/tickets/new-ticket/new-ticket.service.js
@@ -1,3 +1,5 @@
+import get from 'lodash/get';
+
 export const name = 'SupportNewTicketService';
 
 export const definition = class SupportNewTicketService {
@@ -28,6 +30,22 @@ export const definition = class SupportNewTicketService {
 
   getSupportLevel() {
     return this.OvhApiMe.v6().supportLevel().$promise;
+  }
+
+  createTicket(issue, subject, serviceName, urgency) {
+    let body = '';
+    body += `${issue.subject}\n`;
+    issue.fields.forEach((field) => {
+      body += `${field.label}\n${field.default}\n`;
+    });
+    body += '\n';
+    return this.OvhApiSupport.v6().createTickets({}, {
+      issueTypeId: issue.id,
+      serviceName,
+      subject,
+      body,
+      urgency: get(urgency, 'id'),
+    }).$promise;
   }
 };
 


### PR DESCRIPTION
Some refactoring & bugfix

refactoring : 
  - since a single issue is used to generate the creation form instead of a list of issues, replace the list of issues with a single one
  - refactor issue-selector by removing unused bindings and simplify controller
bugfix : 
  - use issueParams in order to prevent the issue-selector to be refreshed multiple times when category changed