### PR TITLE
fix(telecom.pack.xdsl.modem.port): send correct value to API

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/pack-xdsl-modem-port.factory.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/pack-xdsl-modem-port.factory.js
@@ -2,6 +2,7 @@ import assignIn from 'lodash/assignIn';
 import identity from 'lodash/identity';
 import isBoolean from 'lodash/isBoolean';
 import pick from 'lodash/pick';
+import pickBy from 'lodash/pickBy';
 import without from 'lodash/without';
 
 angular.module('managerApp').factory('PackXdslModemPortObject', (OvhApiXdsl, $translate, TucToast) => {
@@ -47,7 +48,7 @@ angular.module('managerApp').factory('PackXdslModemPortObject', (OvhApiXdsl, $tr
           xdslId: serviceName,
           name: this.name,
         },
-        pick(pick(this.tempValue, Object.keys(template)), identity),
+        pickBy(pick(this.tempValue, Object.keys(template)), identity),
       ).$promise.then(() => {
         assignIn(self, self.tempValue);
         self.toggleEdit(false);
@@ -63,7 +64,7 @@ angular.module('managerApp').factory('PackXdslModemPortObject', (OvhApiXdsl, $tr
       {
         xdslId: serviceName,
       },
-      pick(pick(this.tempValue, Object.keys(template)), identity),
+      pickBy(pick(this.tempValue, Object.keys(template)), identity),
     ).$promise.then((data) => {
       assignIn(self, pick(data, Object.keys(template)));
       self.toggleEdit(false);


### PR DESCRIPTION
In Lodash 3, you could do `pick(xxx, identity)` to remove empty values but with Lodash 4 you have to do `pickBy(xxx, identity)`

No other usages for the rest of the monorepo (except Dedicated but the prod version is not in the monorepo yet)

MANAGER-3355