### PR TITLE
build(deps): upgrade ovh-api-services to v9.12.0

### DIFF
--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -115,7 +115,7 @@
     "ovh-angular-browser-alert": "ovh-ux/ovh-angular-browser-alert#^1.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
     "ovh-angular-responsive-page-switcher": "ovh-ux/ovh-angular-responsive-page-switcher#^1.1.0",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.1.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -113,7 +113,7 @@
     "office-ui-fabric-react": "^4.35.2",
     "ovh-angular-browser-alert": "ovh-ux/ovh-angular-browser-alert#^1.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.8.1",
     "ovh-ui-kit": "^2.34.1",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -43,7 +43,7 @@
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.8.1",
     "ovh-ui-kit": "^2.34.1",

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -44,7 +44,7 @@
     "jquery-ui": "^1.12.1",
     "matchmedia-ng": "^1.0.8",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.8.1",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -60,7 +60,7 @@
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.22.2",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.8.1",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -40,7 +40,7 @@
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-ngstrap": "^4.0.2",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -34,7 +34,7 @@
     "jsplumb": "^2.11.2",
     "lodash": "^4.17.15",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit": "^2.34.1",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -33,7 +33,7 @@
     "jsplumb": "^2.11.2",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.8.1",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -131,7 +131,7 @@
     "ovh-angular-timeline": "^1.5.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
     "ovh-angular-user-pref": "^0.3.1",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.0.1",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.8.1",
     "ovh-ui-kit": "^2.34.1"

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -110,7 +110,7 @@
     "ng-ckeditor": "^2.0.5",
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-react": "^4.35.2",
-    "ovh-api-services": "^9.10.1",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-ui-angular": "^3.8.1",
     "ovh-ui-kit": "^2.34.1",

--- a/packages/manager/modules/banner/package.json
+++ b/packages/manager/modules/banner/package.json
@@ -39,6 +39,6 @@
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.8.0"
+    "ovh-api-services": "^9.12.0"
   }
 }

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -52,7 +52,7 @@
     "angular-translate": "^2.11.0",
     "angular-ui-bootstrap": "~1.3.3",
     "d3": "~3.5.13",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ui-angular": "^3.8.0"
   }
 }

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -49,7 +49,7 @@
     "angular-sanitize": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-translate-loader-pluggable": "^1.3.1",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ui-angular": "^3.8.0"
   }
 }

--- a/packages/manager/modules/emailpro/package.json
+++ b/packages/manager/modules/emailpro/package.json
@@ -27,7 +27,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "ng-ckeditor": "^2.0.5",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ui-angular": "^3.8.0"
   }
 }

--- a/packages/manager/modules/exchange/package.json
+++ b/packages/manager/modules/exchange/package.json
@@ -28,7 +28,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "ng-ckeditor": "^2.0.5",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ui-angular": "^3.8.0"
   }
 }

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -44,7 +44,7 @@
     "angular-translate": "^2.18.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ui-angular": "^3.8.0",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -46,7 +46,7 @@
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
     "bootstrap-tour": "^0.12.0",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ui-angular": "^3.8.0",
     "ovh-ui-kit": "^2.33.3"
   }

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -56,7 +56,7 @@
     "font-awesome": "^4.0.0",
     "jquery-ui": "components/jqueryui#~1.11.2",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-angular": "^3.8.0",

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -43,6 +43,6 @@
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.7.0"
+    "ovh-api-services": "^9.12.0"
   }
 }

--- a/packages/manager/modules/sharepoint/package.json
+++ b/packages/manager/modules/sharepoint/package.json
@@ -20,7 +20,7 @@
     "@ovh-ux/ng-ovh-utils": "^14.0.3",
     "@ovh-ux/web-universe-components": "^7.0.0",
     "angular": "^1.7.5",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ui-angular": "^3.8.0",
     "ovh-ui-kit": "^2.33.3"
   }

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -59,7 +59,7 @@
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/telecom-dashboard/package.json
+++ b/packages/manager/modules/telecom-dashboard/package.json
@@ -50,7 +50,7 @@
     "angular-translate": "^2.18.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "lodash": "^4.17.14",
-    "ovh-api-services": "^9.8.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -42,7 +42,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-angular": "^3.8.0",
     "ovh-ui-kit": "^2.33.3",

--- a/packages/manager/modules/telecom-universe-components/package.json
+++ b/packages/manager/modules/telecom-universe-components/package.json
@@ -38,7 +38,7 @@
     "jsplumb": "^2.11.2",
     "moment": "^2.15.2",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.8.0",
     "punycode": "^2.1.1",

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -53,7 +53,7 @@
     "angular-ui-bootstrap": "~1.3.3",
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/web-universe-components/package.json
+++ b/packages/manager/modules/web-universe-components/package.json
@@ -42,7 +42,7 @@
     "ipaddr.js": "^1.9.1",
     "jquery": "^2.1.3",
     "moment": "^2.16.0",
-    "ovh-api-services": "^9.7.0",
+    "ovh-api-services": "^9.12.0",
     "ovh-ui-angular": "^3.8.0",
     "punycode": "^2.1.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11742,10 +11742,10 @@ ovh-angular-user-pref@^0.3.1:
   resolved "https://registry.yarnpkg.com/ovh-angular-user-pref/-/ovh-angular-user-pref-0.3.1.tgz#07f5792513651f3262ae4879c174423649b08307"
   integrity sha1-B/V5JRNlHzJirkh5wXRCNkmwgwc=
 
-ovh-api-services@^9.10.1:
-  version "9.10.1"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.10.1.tgz#1c825eebfdd83f1e8354b3b8d253f6cb2ce1cfff"
-  integrity sha512-BLNh0jXHMKs/uZZvB6XsFbK9A96V2kMIg2cF6PeHik1xygzeVQjS8V7CECnv26nVzSIr0CNqGDEphBpFBgLmDQ==
+ovh-api-services@^9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.12.0.tgz#c75a8344f89670948657719b170b7a92a9aac810"
+  integrity sha512-Epo0eSsSNXT4CvafeP/SJfXwAkk0DeaNDIpmvYjy6krOiQ5TwbcyozRZfQIzKN7iQRY+/4Y47ZS3dhhdLOF4Pg==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
# Upgrade ovh-api-services to v9.12.0

## :arrow_up: Upgrade

babf0db - build(deps): upgrade ovh-api-services to v9.12.0

uses: `yarn upgrade-interactive --latest ovh-api-services`
- ovh-api-services@9.12.0

## :house: Internal

- No quality check required.