### PR TITLE
build(dev-deps): upgrade execa to v2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-import-resolver-lerna": "^1.1.0",
     "eslint-plugin-angular": "^4.0.1",
     "eslint-plugin-markdown": "^1.0.0",
-    "execa": "^1.0.0",
+    "execa": "^2.0.4",
     "find-free-port": "^2.0.0",
     "git-raw-commits": "^2.0.0",
     "git-url-parse": "^11.1.2",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,8 +14,9 @@ let i = 0;
 async function retrieveDependencies(_modules) {
   const packages = await Promise.all(
     _modules.map(pck => execa
-      .shell(
+      .command(
         `lerna list -alp --include-filtered-dependencies --json --scope="${pck.name}"`,
+        { shell: true },
       )
       .then(({ stdout }) => {
         const dependents = JSON.parse(stdout).filter(
@@ -90,7 +91,7 @@ program
   .option('-p, --package [package]', 'Scope build to a specific package and its dependencies')
   .action(() => {
     execa
-      .shell(`lerna list -alp --json ${program.package ? `--scope=${program.package} --include-filtered-dependencies` : ''}`)
+      .command(`lerna list -alp --json ${program.package ? `--scope=${program.package} --include-filtered-dependencies` : ''}`, { shell: true })
       .then(({ stdout }) => retrieveDependencies(JSON.parse(stdout)))
       .then((todo) => {
         modules = {

--- a/scripts/common/repository.js
+++ b/scripts/common/repository.js
@@ -11,24 +11,24 @@ const semver = require('semver');
 
 class MonoRepository {
   static getName() {
-    return execa.shell('git rev-parse --show-toplevel')
+    return execa.command('git rev-parse --show-toplevel', { shell: true })
       .then(({ stdout }) => path.basename(stdout));
   }
 
   static hasUntrackedChanges() {
-    return execa.shell('git status -s')
+    return execa.command('git status -s', { shell: true })
       .then(({ stdout }) => stdout.length > 0);
   }
 
   static getRepositories(includePrivate = false) {
-    return execa.shell(`npx lerna ls ${includePrivate ? '-a' : ''}  --json`)
+    return execa.command(`npx lerna ls ${includePrivate ? '-a' : ''}  --json`, { shell: true })
       .then(({ stdout }) => JSON.parse(stdout))
       .then(repos => repos.map(repo => new Repository(repo)));
   }
 
   static getReleaseVersion(version) {
     const result = version.toLowerCase().trim().replace(' ', '-');
-    return execa.shell(`git tag -l '${version}*' --sort=taggerdate | tail -1`)
+    return execa.command(`git tag -l '${version}*' --sort=taggerdate | tail -1`, { shell: true })
       .then(({ stdout }) => stdout)
       .then((v) => {
         if (v) {
@@ -45,9 +45,9 @@ class MonoRepository {
 
   static release(version, repos) {
     const commitMsg = repos.map(r => `* Package ${r.name} ${r.getPackageJson().version}`).join('\n');
-    return execa.shell(`git add . && git commit -m 'Release: ${version}' -m '${commitMsg}' --no-verify`)
-      .then(() => execa.shell(`git tag -a -m 'release: ${version}' '${version}'`))
-      .then(v => execa.shell('git push origin master --tags').then(() => v));
+    return execa.command(`git add . && git commit -m 'Release: ${version}' -m '${commitMsg}' --no-verify`, { shell: true })
+      .then(() => execa.command(`git tag -a -m 'release: ${version}' '${version}'`))
+      .then(v => execa.command('git push origin master --tags').then(() => v));
   }
 
   static writeChangelog(file, repos) {
@@ -125,22 +125,22 @@ class Repository {
   }
 
   static fetchTags() {
-    return execa.shell('git describe --abbrev=0').then(({ stdout }) => stdout).catch(() => '');
+    return execa.command('git describe --abbrev=0', { shell: true }).then(({ stdout }) => stdout).catch(() => '');
   }
 
   createSmokeTag(tag) {
-    return execa.shell(`git tag ${this.name}@${this.version} ${tag}`);
+    return execa.command(`git tag ${this.name}@${this.version} ${tag}`, { shell: true });
   }
 
   deleteSmokeTag() {
-    return execa.shell(`git tag -d ${this.name}@${this.version}`);
+    return execa.command(`git tag -d ${this.name}@${this.version}`, { shell: true });
   }
 
   updateChangelog() {
-    const getChangelog = () => execa.shell(`lerna exec --scope ${this.name} --concurrency 1 --no-sort -- conventional-changelog \
-      --preset angular --lerna-package ${this.name} --commit-path ${this.location}`);
-    const updateChangelog = () => execa.shell(`lerna exec --scope ${this.name} --concurrency 1 --no-sort -- conventional-changelog \
-      --preset angular --infile CHANGELOG.md --same-file --lerna-package ${this.name} --commit-path ${this.location}`);
+    const getChangelog = () => execa.command(`lerna exec --scope ${this.name} --concurrency 1 --no-sort -- conventional-changelog \
+      --preset angular --lerna-package ${this.name} --commit-path ${this.location}`, { shell: true });
+    const updateChangelog = () => execa.command(`lerna exec --scope ${this.name} --concurrency 1 --no-sort -- conventional-changelog \
+      --preset angular --infile CHANGELOG.md --same-file --lerna-package ${this.name} --commit-path ${this.location}`, { shell: true });
     return Repository.fetchTags()
       .then((...args) => this.createSmokeTag(args))
       .then(() => getChangelog()

--- a/scripts/webpack-cypress.js
+++ b/scripts/webpack-cypress.js
@@ -4,12 +4,12 @@ const kill = require('kill-port');
 const tcpPortUsed = require('tcp-port-used');
 
 fp(3000, (err, port) => {
-  const webpackApp = execa.shell(`yarn start:dev --port ${port}`);
+  const webpackApp = execa('yarn', ['start:dev', '--port', port]);
   webpackApp.stdout.pipe(process.stdout);
 
   tcpPortUsed.waitUntilUsed(port, 500, 1000 * 60 * 5)
     .then(() => {
-      const cypressShell = execa.shell(`cypress run --config baseUrl=http://localhost:${port}`);
+      const cypressShell = execa('cypress', ['run', '--config', `baseUrl=http://localhost:${port}`]);
       cypressShell.stdout.pipe(process.stdout);
       return cypressShell;
     })

--- a/scripts/worker/build_module.js
+++ b/scripts/worker/build_module.js
@@ -2,5 +2,5 @@ const { parentPort, workerData } = require('worker_threads');
 const execa = require('execa');
 
 execa
-  .shell(`cd ${workerData.location} && npm run build --if-present`)
+  .command(`cd ${workerData.location} && npm run build --if-present`, { shell: true })
   .then(() => parentPort.postMessage(`done ${workerData.name}`));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6753,6 +6753,21 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-2.0.4.tgz#2f5cc589c81db316628627004ea4e37b93391d8e"
+  integrity sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==
+  dependencies:
+    cross-spawn "^6.0.5"
+    get-stream "^5.0.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^3.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 execall@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
@@ -7580,6 +7595,13 @@ get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
+
+get-stream@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   dependencies:
     pump "^3.0.0"
 
@@ -9108,6 +9130,11 @@ is-stream@^1.0.1, is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
 is-supported-regexp-flag@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz#21ee16518d2c1dd3edd3e9a0d57e50207ac364ca"
@@ -10540,6 +10567,11 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
@@ -10636,7 +10668,7 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -11312,6 +11344,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
+  integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+  dependencies:
+    path-key "^3.0.0"
+
 npm-which@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
@@ -11548,6 +11587,13 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
 
 opener@^1.4.3:
   version "1.5.1"
@@ -11820,6 +11866,11 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-finally@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
+  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
 p-is-promise@^2.0.0:
   version "2.1.0"
@@ -12116,6 +12167,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
+path-key@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
+  integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
 
 path-parse@1.0.6, path-parse@^1.0.6:
   version "1.0.6"
@@ -14716,6 +14772,11 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-indent@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# Upgrade execa to v2.0.4

- Replace some `execa.shell` by `execa.command` (breaking change).
- Replace some `execa.shell` by a direct call to `execa` API.
- Refer directly to the `lerna` binary instead of using `npx lerna`.

## :arrow_up: Upgrade

4830bcf - build(dev-deps): upgrade execa to v2.0.4

uses: `yarn upgrade-interactive --latest execa`
- execa@2.0.4

ref: https://github.com/sindresorhus/execa/releases/tag/v2.0.0 (breaking changes)

cc @jleveugle 