### PR TITLE
build(lint-staged): ignore some dist pattern when using htmlhint

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,6 +1,6 @@
 {
   "*.html": [
-    "htmlhint 'packages/**/*.html'"
+    "htmlhint --ignore \"**/dist/**,**/dist-EU/**,**/dist-CA/**,**/dist-US/**\" \"packages/**/*.html\""
   ],
   "*.js": [
     "eslint --fix",


### PR DESCRIPTION
# Ignore some dist pattern when using htmlhint

## :construction_worker_man: Build

90712d4 - build(lint-staged): ignore some dist pattern when using htmlhint

ref: #1385