### PR TITLE
Tools - Remove extra version script

### DIFF
--- a/packages/manager/tools/component-rollup-config/package.json
+++ b/packages/manager/tools/component-rollup-config/package.json
@@ -28,9 +28,7 @@
     "lint:md": "eslint --quiet --fix --format=pretty --ext .md .",
     "lint:ts": "eslint --quiet --fix --format=pretty ./src/**/*.ts",
     "prepare": "yarn run build",
-    "test": "yarn run build && yarn run lint && mocha",
-    "version": "npx conventional-changelog-cli -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
-    "postversion": "git push && git push --tags"
+    "test": "yarn run build && yarn run lint && mocha"
   },
   "dependencies": {
     "@babel/core": "^7.5.5",

--- a/packages/manager/tools/webpack-config/package.json
+++ b/packages/manager/tools/webpack-config/package.json
@@ -27,9 +27,7 @@
     "dev:watch": "tsc -w",
     "lint": "eslint --quiet --fix src",
     "prepare": "yarn run build",
-    "test": "eslint --quiet src",
-    "version": "npx conventional-changelog-cli -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
-    "postversion": "git push && git push --tags"
+    "test": "eslint --quiet src"
   },
   "dependencies": {
     "@babel/core": "^7.5.5",

--- a/packages/manager/tools/webpack-dev-server/package.json
+++ b/packages/manager/tools/webpack-dev-server/package.json
@@ -23,9 +23,7 @@
     "dev:watch": "tsc -w",
     "lint": "eslint --quiet --fix src",
     "prepare": "yarn run build",
-    "test": "eslint --quiet src",
-    "version": "npx conventional-changelog-cli -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
-    "postversion": "git push && git push --tags"
+    "test": "eslint --quiet src"
   },
   "dependencies": {
     "base64url": "^3.0.0",


### PR DESCRIPTION
# Remove extra version script

In the monorepo context theses scripts are no more useful.

Please refer to the release script instead: https://github.com/ovh-ux/manager/blob/master/scripts/common/repository.js#L139-L153

## :construction_worker_man: Build

292f736 - build(tools): remove extra version script for component-rollup-config
12122b1 - build(tools): remove extra version script for manager-webpack-config
80e32a6 - build(tools): remove extra version script for manager-webpack-dev-server

## :house: Internal

- No quality check required.
