### PR TITLE
Upgrade ng-ovh-otrs to v7.1.11

### DIFF
--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -46,7 +46,7 @@
     "@ovh-ux/ng-ovh-http": "^4.0.2",
     "@ovh-ux/ng-ovh-jquery-ui-droppable": "^1.0.0",
     "@ovh-ux/ng-ovh-jsplumb": "^5.0.0",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.6",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.11",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -45,7 +45,7 @@
     "@ovh-ux/ng-ovh-export-csv": "^1.0.1",
     "@ovh-ux/ng-ovh-http": "^4.0.2",
     "@ovh-ux/ng-ovh-jquery-ui-draggable": "^1.0.0",
-    "@ovh-ux/ng-ovh-otrs": "7.1.11",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.11",
     "@ovh-ux/ng-ovh-payment-method": "^4.2.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -20,7 +20,7 @@
     "@ovh-ux/ng-ovh-apiv7": "^2.0.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.1",
     "@ovh-ux/ng-ovh-contacts": "^1.0.1",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.4",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.11",
     "@ovh-ux/ng-ovh-payment-method": "^4.2.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/ng-ovh-chatbot": "^2.0.1",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.1",
     "@ovh-ux/ng-ovh-contacts": "^1.0.1",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.4",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.11",
     "@ovh-ux/ng-ovh-payment-method": "^4.2.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -44,7 +44,7 @@
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.1",
     "@ovh-ux/ng-ovh-export-csv": "^1.0.1",
     "@ovh-ux/ng-ovh-http": "^4.0.4",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.6",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.11",
     "@ovh-ux/ng-ovh-payment-method": "^4.2.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",

--- a/packages/manager/modules/exchange/package.json
+++ b/packages/manager/modules/exchange/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@ovh-ux/ng-ovh-export-csv": "^1.0.0",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.7",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.11",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",
     "@ovh-ux/ng-ovh-user-pref": "^1.0.0",
     "@ovh-ux/ng-ovh-utils": "^14.0.3",

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -35,7 +35,7 @@
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.2",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.1",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.4",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.11",
     "@ovh-ux/ng-ovh-payment-method": "^4.1.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,18 +1999,10 @@
     ovh-ui-kit "^2.23.1"
     ovh-ui-kit-bs "^2.1.1"
 
-"@ovh-ux/ng-ovh-otrs@7.1.11", "@ovh-ux/ng-ovh-otrs@^7.1.6":
+"@ovh-ux/ng-ovh-otrs@7.1.11", "@ovh-ux/ng-ovh-otrs@^7.1.11", "@ovh-ux/ng-ovh-otrs@^7.1.6":
   version "7.1.11"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.11.tgz#39fec6c9f6cdf8cb4c292e8ed4dca759c4cd1acf"
   integrity sha512-vZzTWZZkVfEuNrAuBNRjZB+4MCdTDaB4qMpLuQy6l5TrflJLrx4H9qzt5DcpEvNWwTzXVMfuOwq+qHrkJQKfwg==
-  dependencies:
-    draggable "^4.2.0"
-    lodash "^4.17.11"
-
-"@ovh-ux/ng-ovh-otrs@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.4.tgz#e49c9696dc9a86281ae4bd3f71c43c1fc4a7a36c"
-  integrity sha512-z+h5clMBoB/9Mxd+k15PLkeZMKQbDKpoPfztaPhcHJBsaK9aJWUZPN2YdxOc1Im4dWkWI4soPF+zI1wFdQGBhA==
   dependencies:
     draggable "^4.2.0"
     lodash "^4.17.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,7 +1999,7 @@
     ovh-ui-kit "^2.23.1"
     ovh-ui-kit-bs "^2.1.1"
 
-"@ovh-ux/ng-ovh-otrs@7.1.11", "@ovh-ux/ng-ovh-otrs@^7.1.11", "@ovh-ux/ng-ovh-otrs@^7.1.6":
+"@ovh-ux/ng-ovh-otrs@^7.1.11":
   version "7.1.11"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.11.tgz#39fec6c9f6cdf8cb4c292e8ed4dca759c4cd1acf"
   integrity sha512-vZzTWZZkVfEuNrAuBNRjZB+4MCdTDaB4qMpLuQy6l5TrflJLrx4H9qzt5DcpEvNWwTzXVMfuOwq+qHrkJQKfwg==


### PR DESCRIPTION
# Upgrade ng-ovh-otrs to v7.1.11

## :arrow_up: Upgrade

063bf9c - build(deps): upgrade ng-ovh-otrs to v7.1.11
3b39289 - build(deps): upgrade ng-ovh-otrs to v7.1.11

## :link: Related

fix #1442

## :house: Internal

- No quality check required.