### PR TITLE
refactor(plugins.translations.utils): remove deprecated languages

### DIFF
--- a/packages/manager/tools/component-rollup-config/src/plugins/translation-utils.ts
+++ b/packages/manager/tools/component-rollup-config/src/plugins/translation-utils.ts
@@ -15,7 +15,6 @@ const ALL_LANGUAGES = [
   'fr_FR',
   'it_IT',
   'lt_LT',
-  'nl_NL',
   'pl_PL',
   'pt_PT',
 ];


### PR DESCRIPTION
# Remove deprecated languages

## :boom: Breaking Change

469ece1 - refactor(plugins.translations.utils): remove deprecated languages

see: https://github.com/ovh-ux/manager/pull/1253

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>

BREAKING CHANGE: remove deprecated nl_NL language