### PR TITLE
Tools - Refers to the right package

### DIFF
--- a/packages/manager/tools/webpack-config/README.md
+++ b/packages/manager/tools/webpack-config/README.md
@@ -70,7 +70,7 @@ module.exports = merge(config, {
 
 ## Related
 
-* [manager-webpack-dev-server](https://github.com/ovh-ux/manager-webpack-dev-server) - OVH manager webpack development server configuration
+* [manager-webpack-dev-server](https://github.com/ovh-ux/manager/tree/master/packages/manager/tools/webpack-dev-server) - OVH manager webpack development server configuration
 
 ## Contributing
 

--- a/packages/manager/tools/webpack-dev-server/README.md
+++ b/packages/manager/tools/webpack-dev-server/README.md
@@ -46,7 +46,7 @@ const env = {
 
 ## Related
 
-* [manager-webpack-config](https://github.com/ovh-ux/manager-webpack-config) - OVH manager shared webpack configuration
+* [manager-webpack-config](https://github.com/ovh-ux/manager/tree/master/packages/manager/tools/webpack-config) - OVH manager shared webpack configuration
 
 ## Contributing
 


### PR DESCRIPTION
# Refers to the right package

Since both packages were imported as is then the related party was referring to
the wrong repository.

## :memo: Documentation

d07faab - docs(readme): refers to the right package manage-webpack-config
e2c6afe - docs(readme): refers to the right package manage-webpack-dev-server

## :link: Related

- #953

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>