### PR TITLE
fix(dedicated): restore display size

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -1432,12 +1432,8 @@ angular
 
 
     // Display size with unit (recursive)
-    $scope.getDisplaySize = function getDisplaySize(octetsSize, _unitIndex) {
-      let unitIndex = _unitIndex;
+    $scope.getDisplaySize = function getDisplaySize(octetsSize, unitIndex = 0) {
       if (!Number.isNaN(octetsSize)) {
-        if (Number.isNaN(unitIndex)) {
-          unitIndex = 0;
-        }
         if (octetsSize >= 1000 && unitIndex < $scope.units.model.length - 1) {
           return $scope.getDisplaySize(octetsSize / 1000, unitIndex + 1);
         }


### PR DESCRIPTION
## fix(dedicated): restore display size

### Description of the Change

Use of `isNaN` was updated to `Number.isNaN` due to eslint error : *Unexpected use of `isNaN` : no-restricted-globals* (https://github.com/ovh-ux/ovh-manager-dedicated/blob/master/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js#L1225)

but

```js
isNaN(undefined) // true
Number.isNaN(undefined) // false
```

ref: MANAGER-3750

7fdc6d1cad — fix(dedicated): restore display size

