### PR TITLE
fix(server.sidebar): hide vps section for US until prod of feature

### DIFF
--- a/packages/manager/modules/server-sidebar/src/sidebar.constants.js
+++ b/packages/manager/modules/server-sidebar/src/sidebar.constants.js
@@ -188,6 +188,7 @@ export const IAAS_CONFIG = {
       loadOnState: 'iaas.vps.detail',
       icon: 'ovh-font ovh-font-vps',
       app: [CLOUD],
+      regions: ['EU', 'CA'],
       searchKeys: ['VPS'],
     },
   ],


### PR DESCRIPTION
ref : MANAGER-3074

Revert enabling vps section

Disable section will have to be reverted once the prod of vps feature will be possible (See : https://github.com/ovh-ux/ovh-manager-cloud/pull/1539)